### PR TITLE
Fix Java build errors caused by UTF-8 source encoding

### DIFF
--- a/py4j-java/build.xml
+++ b/py4j-java/build.xml
@@ -117,11 +117,11 @@
     <!-- JAVA - COMPILE -->
     <target depends="init" name="build">
         <echo message="${ant.project.name}: ${ant.file}"/>
-        <javac debug="true" debuglevel="${debuglevel}" destdir="${build.dir}" source="${source}" target="${target}">
+        <javac debug="true" debuglevel="${debuglevel}" destdir="${build.dir}" source="${source}" target="${target}" encoding="UTF-8">
             <src path="src"/>
             <classpath refid="py4j.classpath"/>
         </javac>
-        <javac debug="true" debuglevel="${debuglevel}" destdir="${build.dir}" source="${source}" target="${target}">
+        <javac debug="true" debuglevel="${debuglevel}" destdir="${build.dir}" source="${source}" target="${target}" encoding="UTF-8">
             <src path="test"/>
             <classpath refid="py4j.classpath"/>
         </javac>

--- a/py4j-java/pom.xml
+++ b/py4j-java/pom.xml
@@ -36,4 +36,9 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
 </project>

--- a/py4j-web/install.rst
+++ b/py4j-web/install.rst
@@ -67,9 +67,10 @@ Briefly, you need:
 1. `Git <http://git-scm.com/>`_ to download the latest source code.
    Execute the command line ``git clone https://github.com/bartdag/py4j.git
    py4j`` to download the source code.
-2. `Apache ant <http://ant.apache.org>`_ to build the Py4J Java library. Just
-   execute the command line ``ant jar`` in the py4j-java project directory to
-   build the code and create a jar file. 
+2. `Apache ant <http://ant.apache.org>`_ to build the Py4J Java library. Set
+   the ``junit.path`` propery in ``py4j-java/ant.properties`` to point to the
+   location of your JUnit 4 jar, then execute the command line ``ant jar`` in
+   the py4j-java project directory to build the code and create a jar file.
 3. `Sphinx <http://sphinx.pocoo.org/>`_ to build the documentation. Just
    execute the command line ``make html``  in the
    py4j-web project.


### PR DESCRIPTION
On my machine (Mac OS 10.7.4), the `py4j-java` build fails due to encoding errors:

I receive this error under both maven and ant:

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /Users/josh/Documents/programming/py4j/py4j-java/test/py4j/examples/UTFExample.java:[7,20] illegal character: \8730
[ERROR] /Users/josh/Documents/programming/py4j/py4j-java/test/py4j/examples/UTFExample.java:[7,21] illegal character: \169
[ERROR] /Users/josh/Documents/programming/py4j/py4j-java/test/py4j/examples/UTFExample.java:[7,22] invalid method declaration; return type required
```

I've run into this issue [in the past](https://code.google.com/p/hyracks/issues/detail?id=38&can=1&q=utf-8); the problem is that the default source encoding used by `javac` on OS X may not be UTF-8.

This patch solves this issue by explicitly specifying the source encoding used by the build.

I also updated the ant build instructions to mention the `junit.path` property that needs to be set in `ant.properties`.

Is `hamcrest.path` used anymore?  I don't see any references to Hamcrest.
