### PR TITLE
Added extra path to find_jar() to ensure jar file found

### DIFF
--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -72,6 +72,8 @@ def find_jar_path():
     paths.append(jar_file)
     paths.append(os.path.join(os.path.dirname(os.path.realpath(__file__)),
             "../../../py4j-java/" + jar_file))
+    paths.append(os.path.join(os.path.dirname(os.path.realpath(__file__)),
+            "../share/py4j/" + jar_file))
     paths.append("../../../current-release/" + jar_file)
     paths.append(os.path.join(sys.prefix, "share/py4j/" + jar_file))
 


### PR DESCRIPTION
I installed py4j using easy_install-2.7 on Ubuntu 12.04.

The jar file ended up in /usr/local/lib/python2.7/dist-packages/py4j-0.8-py2.7.egg/share/py4j/py4j0.8.jar , which wasn't included in any of the list of paths in find_jar(). The attached patch fixes this for me.
