### PR TITLE
Remove duplicate import_str in java_import command

### DIFF
--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -57,7 +57,6 @@ def java_import(jvm_view, import_str):
     gateway_client = jvm_view._gateway_client
     command = JVMVIEW_COMMAND_NAME + JVM_IMPORT_SUB_COMMAND_NAME +\
             jvm_view._id + '\n' + escape_new_line(import_str) + '\n' +\
-            END_COMMAND_PART + '\n' + escape_new_line(import_str) + '\n' +\
             END_COMMAND_PART
     answer = gateway_client.send_command(command)
     return_value = get_return_value(answer, gateway_client, None, None)


### PR DESCRIPTION
Change,

commit 5411cb545d18cb8c74610531c1cf2fa704d67751
Author: Barthelemy Dagenais bart@cs.mcgill.ca
Date:   Sat Mar 12 13:08:27 2011 -0500
    initial work on supporting byte[] and cleaning unicode treatment...

appears to have duplicated the import_str sent to the server during
java_import. The duplication does not cause a fatal error or incorrect
behavior, but does generate a warning from the server about unknown
commands.

For instance, java_import(..., "org.apache.spark.SparkConf") results
in,

   Command to send: j
   i
   rj
   org.apache.spark.SparkConf
   e

   org.apache.spark.SparkConf
   e

and,

   py4j.GatewayConnection run
   WARNING: Unknown command
   py4j.GatewayConnection run
   WARNING: Unknown command org.apache.spark.SparkConf
   py4j.GatewayConnection run
   WARNING: Unknown command e
