### PR TITLE
Sped up unescape_new_line

### DIFF
--- a/py4j-python/src/py4j/protocol.py
+++ b/py4j-python/src/py4j/protocol.py
@@ -170,24 +170,7 @@ def unescape_new_line(escaped):
 
     :rtype: the original string
     """
-    escaping = False
-    original = ''
-    for c in escaped:
-        if not escaping:
-            if c == ESCAPE_CHAR:
-                escaping = True
-            else:
-                original += c
-        else:
-            if c == 'n':
-                original += '\n'
-            elif c == 'r':
-                original += '\r'
-            else:
-                original += c
-            escaping = False
-
-    return original
+    return ESCAPE_CHAR.join( '\n'.join(('\r'.join(p.split(ESCAPE_CHAR + 'r'))).split(ESCAPE_CHAR + 'n')) for p in escaped.split(ESCAPE_CHAR + ESCAPE_CHAR) )
 
 
 def smart_decode(s):


### PR DESCRIPTION
I was seeing a heavy performance hit when getting larger objects through py4j (maybe the same problem discussed in issue #146). 
I traced the problem down to the unescape_new_line in protocol.py, which runs for a very long time on long strings. I have replaced the implementation with an implementation utilizing the native implementations of the python methods.

A comparison of performance: 

```
In [23]: print(time.time()); print(hash(unescape_new_line(about_a_million_character_string))); print(time.time())
1413979817.67
9136211936225273955
1413980082.09

In [28]: print(time.time()); print(hash(unescape_new_line2(about_a_million_character_string))); print(time.time())
1413980303.31
9136211936225273955
1413980303.32
```

So time taken went from from 264 seconds to 0.01 seconds.

I hope that you will merge this pull request.
