### PR TITLE
Catch KeyboardInterrupt when sending comments to prevent leaking

### DIFF
--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -1056,6 +1056,12 @@ class GatewayClient(object):
                     "Exception while sending command.")
                 response = proto.ERROR
         except KeyboardInterrupt:
+            # For KeyboardInterrupt triggered from Python shell, it should
+            # clean up the connection so the connection is
+            #   - closed and does not leak
+            #   - removed from the thread local when Py4J Single Threading Model is on
+            # See also https://github.com/bartdag/py4j/pull/440 for more details.
+            logging.exception("KeyboardInterrupt while sending command.")
             if connection:
                 connection.close(False)
             raise


### PR DESCRIPTION
## What does this PR propose?

This PR proposes to catch `KeyboardInterrupt` when failing to send some commands, and close the given connection in order to:

1. Avoid leaking (with Py4J default mode).
2. Avoid the corrupt connection being resued (with [Py4J Single Threading Model](https://www.py4j.org/py4j_client_server.html)).

## What does this PR fix?

The issue is that if `KeyboardInterrupt` is raised, usually Python shells just stop but it's not the case in notebooks such as Jupyter. Jupyter catches `KeyboardInterrupt` and keeps the Python interpreter alive. In this case, there are one minor in Py4J with default connection handling model, and one major problem with [Py4J Single Threading Model](https://www.py4j.org/py4j_client_server.html):

### Py4J single threading model

**What?**

Assume you run a cell as below:

![Screen Shot 2021-10-14 at 4 07 09 PM](https://user-images.githubusercontent.com/6477701/137268793-5b559782-49dd-4f9e-b082-1423213b1460.png)

and interrupt the job via:

![Screen Shot 2021-10-14 at 4 09 44 PM](https://user-images.githubusercontent.com/6477701/137268724-cc0a23c8-7082-430a-83e7-c036c7e63364.png)

It fails as below (which is expected):

![Screen Shot 2021-10-14 at 4 05 05 PM](https://user-images.githubusercontent.com/6477701/137268690-f05f7ef3-d9c7-4da2-ac2e-067c21db168c.png)

Now, you run other cells again. Then, all the following cells fail even though you don't interrupt or cancel:

![Screen Shot 2021-10-14 at 4 08 49 PM](https://user-images.githubusercontent.com/6477701/137268859-ba5f10f3-4aa7-44bc-b001-8fd2d4ec5030.png)

**Why?**

This is because the `connection` you used when interrupting the first job still remains in your local thread. This is reused for other jobs afterwards as below:

https://github.com/bartdag/py4j/blob/366de7a527df122f4c5b50a5aa10fb69cd47a089/py4j-python/src/py4j/clientserver.py#L268-L282

It causes unexpected behaviours as the connection being (re)used here is corrupted without closing.

For other exceptions, we always close the socket via:

https://github.com/bartdag/py4j/blob/366de7a527df122f4c5b50a5aa10fb69cd47a089/py4j-python/src/py4j/clientserver.py#L468-L471

https://github.com/bartdag/py4j/blob/366de7a527df122f4c5b50a5aa10fb69cd47a089/py4j-python/src/py4j/java_gateway.py#L1045-L1050

However, `KeyboardInterrupt` inherits `BaseException` instead of `Exception`. So it exists without closing the connection.

**Py4J with default connection handling model**

For default mode in Py4J, minor issue happens. Because we pop the connection from deque to reuse:

https://github.com/bartdag/py4j/blob/366de7a527df122f4c5b50a5aa10fb69cd47a089/py4j-python/src/py4j/java_gateway.py#L978-L985

the `connection` becomes orphan and leaks. Following jobs are not affected because the `connection` does not exist in `deque` and does not get reused but the socket resource leaks without being closed.

## How did you test?

I made a full build and tested with PySpark in Apache Spark. With/without this fix, and with/without single threaded mode.