### PR TITLE
Add support for Java 17

### DIFF
--- a/py4j-java/build.gradle
+++ b/py4j-java/build.gradle
@@ -126,8 +126,8 @@ if (jdk6BootClasspath) {
 }
 
 tasks.withType(JavaCompile) {
-    sourceCompatibility = "1.6"
-    targetCompatibility = "1.6"
+    sourceCompatibility = "9"
+    targetCompatibility = "9"
     options.fork = true
     options.encoding = "UTF-8"
 }

--- a/py4j-java/gradle.properties
+++ b/py4j-java/gradle.properties
@@ -1,8 +1,8 @@
 group=py4j
 bundleVersion=0.10.9.3
 version=0.10.9.3
-sourceCompatibility=1.6
-targetCompatibility=1.6
+sourceCompatibility=9
+targetCompatibility=9
 # Define the jdk6BootClasspath in your ~/.gradle/gradle.properties
 jdk6BootClasspath=
 # Define the eclipseHomePath in your ~/.gradle/gradle.properties

--- a/py4j-java/src/main/java/py4j/reflection/MethodInvoker.java
+++ b/py4j-java/src/main/java/py4j/reflection/MethodInvoker.java
@@ -237,13 +237,13 @@ public class MethodInvoker {
 			if (method != null) {
 				AccessController.doPrivileged(new PrivilegedAction<Object>() {
 					public Object run() {
-						method.setAccessible(true);
+						method.trySetAccessible();
 						return null;
 					}
 				});
 				returnObject = method.invoke(obj, newArguments);
 			} else if (constructor != null) {
-				constructor.setAccessible(true);
+				constructor.trySetAccessible();
 				returnObject = constructor.newInstance(newArguments);
 			}
 		} catch (InvocationTargetException ie) {


### PR DESCRIPTION
This tries to address #403 and a few related issues, by implementing Option 3 from https://github.com/bartdag/py4j/issues/403#issuecomment-782728385.

Unfortunately(?) this raises the minimum JDK version to 9.
I agree that it's not possible to properly solve this, while also supporting both Java 8 and Java 17, with a single build.

I also gave Option 1 a try, but that way not even `getCallbackClient()` was accessible, so I didn't pursue it further.