### PR TITLE
Adds venv and .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 /build
+venv
+.idea


### PR DESCRIPTION
This PR proposes to add `venv` and `.idea` to `.gitignore`. 

`venv` can be created by [virtual environment](https://docs.python.org/3/library/venv.html)
`.idea` is created by [PyCharm](https://www.jetbrains.com/pycharm/promo/?source=google&medium=cpc&campaign=14123077093&gclid=Cj0KCQiA3-yQBhD3ARIsAHuHT64XonV3K7ORd-uilTj9b3YbqqapmULnnXumNYyHEayQe4erRRJuT7AaAt7xEALw_wcB) and [IntelliJ](https://www.jetbrains.com/idea/)

Both are metadata, and shouldn't be managed via Py4J source codes.