### PR TITLE
Add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,9 @@ setup(
                      "through standard Python collection methods. Py4J also "
                      "enables Java programs to call back Python objects.",
     url="https://www.py4j.org/",
+    project_urls={
+        "Source": "https://github.com/py4j/py4j",
+    },
     author="Barthelemy Dagenais",
     author_email="barthelemy@infobart.com",
     license="BSD License",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.