### PR TITLE
Fix minor typo & command for documentation

### DIFF
--- a/py4j-web/contributing.rst
+++ b/py4j-web/contributing.rst
@@ -113,7 +113,6 @@ suite across the supported python versions.
   ./gradlew assemble
 
   # install test requirements
-  cd py4j-python
   pip install -r requirements.txt
 
   # Run the full test suite
@@ -183,7 +182,7 @@ your commit:
 
         fixes #XYZ -- short description below 72 characters
 
-        Longer description that lists all the changes that occured
+        Longer description that lists all the changes that occurred
         on multiple lines of 79 characters.
 
 

--- a/py4j-web/contributing.rst
+++ b/py4j-web/contributing.rst
@@ -107,13 +107,17 @@ suite across the supported python versions.
 
 .. code-block:: bash
 
-  # make sure that the jar file is created
+  # Make sure that the jar file is created
   cd py4j-java
   ./gradlew clean
   ./gradlew assemble
 
-  # install test requirements
-  pip install -r requirements.txt
+  # Come back to home directory
+  cd ..
+
+  # Install test requirements for Python
+  cd py4j-python
+  pip install -r requirements-test.txt
 
   # Run the full test suite
   nosetests

--- a/py4j-web/install.rst
+++ b/py4j-web/install.rst
@@ -105,4 +105,4 @@ Maven install
 2. Go to the py4j-java directory and execute ``mvn install``.
 3. Alternatively, if a test fails (possible because of sockets), execute
    ``mvn -Dmaven.test.skip=true install``
-4. Builded binaries will be in the directory ``target/py4j-0.x.jar``.
+4. Built binaries will be in the directory ``target/py4j-0.x.jar``.

--- a/py4j-web/py4j_java_gateway.rst
+++ b/py4j-web/py4j_java_gateway.rst
@@ -294,7 +294,7 @@ They are all instances of :class:`Signal <py4j.signals.Signal>`.
 
 .. py:data:: post_server_shutdown
 
-    Signal sent when a Python (Callback) Server is shutted down.
+    Signal sent when a Python (Callback) Server is shut down.
 
     Will supply the ``server`` argument, an instance of CallbackServer
 


### PR DESCRIPTION
This PR proposes to fix minor typo and command for documentation as below:

**command**
- remove the command `cd py4j-python` in [Testing Python Code](py4j-web/contributing.rst), since `requirements.txt` is in the project root path, not in `/py4j-python`.

**typos**
- occured -> occurred
- Builded -> Built
- shutted -> shut