### PR TITLE
Keep CNAME in GitHub Pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,7 @@ jobs:
 
           rm -fr * # Remove existing site
           touch .nojekyll # See https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages
+          echo "www.py4j.org" > CNAME # Custom domain for GitHub Actions
           cp -r ../html/* . # Move generated site to the current repo.
 
       - name: Push new site


### PR DESCRIPTION
We should keep `CNAME`. Otherwise, it will be removed, see also https://github.com/py4j/py4j/commit/bdf851b14e45fdc4b216721bd070bf647bac8c9a