### PR TITLE
Use automatically pickled in the ephemeral port range at ProxyTest

### DIFF
--- a/py4j-java/src/test/java/py4j/ProxyTest.java
+++ b/py4j-java/src/test/java/py4j/ProxyTest.java
@@ -48,15 +48,26 @@ public class ProxyTest {
 	public void setup() {
 		// GatewayServer.turnLoggingOn();
 		entry = new InterfaceEntry();
-		gServer = new GatewayServer(entry);
 		pClient = new PythonTestClient();
-		gServer.start();
 		pClient.startProxy();
 		try {
 			Thread.sleep(250);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
+
+		gServer = new GatewayServer(entry, 0, pClient.getPort(), GatewayServer.DEFAULT_CONNECT_TIMEOUT,
+				GatewayServer.DEFAULT_READ_TIMEOUT, null);
+		gServer.start();
+		try {
+			Thread.sleep(250);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		int port = gServer.getListeningPort();
+		assert port != -1;
+		pClient.setPythonPort(gServer.getListeningPort());
 	}
 
 	@After

--- a/py4j-java/src/test/java/py4j/PythonTestClient.java
+++ b/py4j-java/src/test/java/py4j/PythonTestClient.java
@@ -44,6 +44,8 @@ public class PythonTestClient implements Runnable {
 	public volatile String nextProxyReturnMessage;
 
 	private ServerSocket sSocket;
+	private volatile int port = 0;
+	private volatile int pythonPort = 0;
 
 	public void startProxy() {
 		new Thread(this).start();
@@ -51,7 +53,8 @@ public class PythonTestClient implements Runnable {
 
 	public void run() {
 		try {
-			sSocket = new ServerSocket(25334);
+			sSocket = new ServerSocket(0);
+			port = sSocket.getLocalPort();
 			Socket socket = sSocket.accept();
 			BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
 			BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
@@ -72,13 +75,22 @@ public class PythonTestClient implements Runnable {
 		}
 	}
 
+	public int getPort() {
+		assert port != 0;
+		return port;
+	}
+
+	public void setPythonPort(int port) {
+		pythonPort = port;
+	}
+
 	public void stopProxy() {
 		NetworkUtil.quietlyClose(sSocket);
 	}
 
 	public void sendMesage(String message) {
 		try {
-			Socket socket = new Socket(InetAddress.getByName(GatewayServer.DEFAULT_ADDRESS), 25333);
+			Socket socket = new Socket(InetAddress.getByName(GatewayServer.DEFAULT_ADDRESS), pythonPort);
 			BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
 			BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
 			writer.write(message);


### PR DESCRIPTION
`testSayHello` at `ProxyTest` is very flaky:

```
py4j.ProxyTest > testSayHello FAILED
    py4j.Py4JNetworkException at ProxyTest.java:53
        Caused by: java.net.BindException at ProxyTest.java:53
```

The reason is that the previous port number in use is not properly closed yet, but this test attempts to use it.

This PR proposes to use automatically pickled in the ephemeral port range at `ProxyTest` by specifying `0`.