### PR TITLE
Using Gradle Wrapper instead of manually installing Gradle for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,15 +95,14 @@ jobs:
         with:
           java-version: 8
           distribution: 'adopt'
+          cache: 'gradle'
 
-      - name: Install Gradle 4.10
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: 4.10
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
 
       - name: Javadoc build
         run: |
-          cd py4j-java && gradle javadoc && cd ..
+          cd py4j-java && ./gradlew javadoc && cd ..
           mv py4j-java/build/docs/javadoc py4j-web/_static/
 
       - name: Sphinx build


### PR DESCRIPTION
This PR proposes to use [Gradle Wrapper Validation Action](https://github.com/gradle/wrapper-validation-action) instead of manually installing Gradle in GitHub Action CI.

Gradle Wrapper automatically set the Gradle build environment so we don't need to manually manage the Gradle like we've been doing so far.