### PR TITLE
Fix flaky test due to too short timeout

### DIFF
--- a/py4j-python/src/py4j/tests/java_gateway_test.py
+++ b/py4j-python/src/py4j/tests/java_gateway_test.py
@@ -1069,8 +1069,7 @@ class GatewayLauncherTest(unittest.TestCase):
             sleep()
             self.assertFalse(self.gateway.java_process.poll() is None)
         else:
-            sleep()
-            self.gateway.java_process.wait(2**-5)
+            self.gateway.java_process.wait(2**-4)
 
     def testJavaopts(self):
         self.gateway = JavaGateway.launch_gateway(javaopts=["-Xmx64m"])

--- a/py4j-python/src/py4j/tests/java_gateway_test.py
+++ b/py4j-python/src/py4j/tests/java_gateway_test.py
@@ -1069,6 +1069,7 @@ class GatewayLauncherTest(unittest.TestCase):
             sleep()
             self.assertFalse(self.gateway.java_process.poll() is None)
         else:
+            sleep()
             self.gateway.java_process.wait(2**-5)
 
     def testJavaopts(self):

--- a/py4j-python/src/py4j/tests/java_gateway_test.py
+++ b/py4j-python/src/py4j/tests/java_gateway_test.py
@@ -1069,7 +1069,7 @@ class GatewayLauncherTest(unittest.TestCase):
             sleep()
             self.assertFalse(self.gateway.java_process.poll() is None)
         else:
-            self.gateway.java_process.wait(2**-4)
+            self.gateway.java_process.wait(1)
 
     def testJavaopts(self):
         self.gateway = JavaGateway.launch_gateway(javaopts=["-Xmx64m"])


### PR DESCRIPTION
This PR proposes to fix flaky test `testShutdownSubprocessThatDiesOnExit`.

The current timeout waiting for shutting down callback server is 0.3125 (2**-5), but seems it's not enough so the test is often failed due to `TimeoutExpired` exception.

Increasing the waiting time to 1 sec may fix the flakiness.

Refer to https://github.com/py4j/py4j/pull/463#issuecomment-1054080032 and https://github.com/py4j/py4j/runs/5389683418?check_suite_focus=true for more detail.

