### PR TITLE
Improve release process and guides

### DIFF
--- a/py4j-java/build.gradle
+++ b/py4j-java/build.gradle
@@ -165,9 +165,9 @@ task createPom {
                 name 'Py4J'
                 description 'Py4J enables Python programs running in a Python interpreter to dynamically access Java objects in a Java Virtual Machine. Methods are called as if the Java objects resided in the Python interpreter and Java collections can be accessed through standard Python collection methods. Py4J also enables Java programs to call back Python objects.'
                 scm {
-                    connection 'scm:git:git@github.com:bartdag/py4j.git'
-                    developerConnection 'scm:git:git@github.com:bartdag/py4j.git'
-                    url 'git@github.com:bartdag/py4j.git'
+                    connection 'scm:git:git@github.com:py4j/py4j.git'
+                    developerConnection 'scm:git:git@github.com:py4j/py4j.git'
+                    url 'git@github.com:py4j/py4j.git'
                 }
                 developers {
                     developer {
@@ -188,13 +188,71 @@ task createPom {
                 }
             }
         }.withXml {
-            asNode().appendNode('build').appendNode('plugins').appendNode('plugin').with {
-                appendNode('groupId', 'org.apache.maven.plugins')
-                appendNode('artifactId', 'maven-compiler-plugin')
-                appendNode('version', '3.3')
-                appendNode('configuration').with {
-                    appendNode('source', '1.6')
-                    appendNode('target', '1.6')
+            asNode().appendNode('distributionManagement').appendNode('snapshotRepository').with {
+                appendNode('id', 'ossrh')
+                appendNode('url', 'https://oss.sonatype.org/content/repositories/snapshots')
+            }
+        }.withXml {
+            asNode().appendNode('build').appendNode('plugins').with {
+                appendNode('plugin').with {
+                    appendNode('groupId', 'org.apache.maven.plugins')
+                    appendNode('artifactId', 'maven-compiler-plugin')
+                    appendNode('version', '3.3')
+                    appendNode('configuration').with {
+                        appendNode('source', '1.6')
+                        appendNode('target', '1.6')
+                    }
+                }
+                appendNode('plugin').with {
+                    appendNode('groupId', 'org.sonatype.plugins')
+                    appendNode('artifactId', 'nexus-staging-maven-plugin')
+                    appendNode('version', '1.6.7')
+                    appendNode('extensions', 'true')
+                    appendNode('configuration').with {
+                        appendNode('serverId', 'ossrh')
+                        appendNode('nexusUrl', 'https://oss.sonatype.org')
+                        appendNode('autoReleaseAfterClose', 'true')
+                    }
+                }
+                appendNode('plugin').with {
+                    appendNode('groupId', 'org.apache.maven.plugins')
+                    appendNode('artifactId', 'maven-gpg-plugin')
+                    appendNode('version', '1.5')
+                    appendNode('executions').with {
+                        appendNode('execution').with {
+                            appendNode('id', 'sign-artifacts')
+                            appendNode('phase', 'verify')
+                            appendNode('goals').with {
+                                appendNode('goal', 'sign')
+                            }
+                        }
+                    }
+                }
+                appendNode('plugin').with {
+                    appendNode('groupId', 'org.apache.maven.plugins')
+                    appendNode('artifactId', 'maven-source-plugin')
+                    appendNode('version', '2.2.1')
+                    appendNode('executions').with {
+                        appendNode('execution').with {
+                            appendNode('id', 'attach-sources')
+                            appendNode('goals').with {
+                                appendNode('goal', 'jar-no-fork')
+                            }
+                        }
+                    }
+                }
+                appendNode('plugin').with {
+                    appendNode('groupId', 'org.apache.maven.plugins')
+                    appendNode('artifactId', 'maven-javadoc-plugin')
+                    appendNode('version', '2.9.1')
+                    appendNode('executions').with {
+                        appendNode('execution').with {
+                            appendNode('id', 'attach-javadocs')
+                            appendNode('goals').with {
+                                appendNode('goal', 'jar')
+                            }
+                        }
+                    }
                 }
             }
         }.writeTo("pom.xml")

--- a/py4j-java/pom.xml
+++ b/py4j-java/pom.xml
@@ -25,9 +25,9 @@
     </developer>
   </developers>
   <scm>
-    <connection>scm:git:git@github.com:bartdag/py4j.git</connection>
-    <developerConnection>scm:git:git@github.com:bartdag/py4j.git</developerConnection>
-    <url>git@github.com:bartdag/py4j.git</url>
+    <connection>scm:git:git@github.com:py4j/py4j.git</connection>
+    <developerConnection>scm:git:git@github.com:py4j/py4j.git</developerConnection>
+    <url>git@github.com:py4j/py4j.git</url>
   </scm>
   <properties>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
@@ -41,6 +41,12 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
   <build>
     <plugins>
       <plugin>
@@ -51,6 +57,57 @@
           <source>1.6</source>
           <target>1.6</target>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/py4j-python/release_process.txt
+++ b/py4j-python/release_process.txt
@@ -1,31 +1,38 @@
 0. Update all versions (version.py, properties, documentation, index.rst).
 1. Write changelog
-2. gradle clean
+2. gradle clean (at py4j/py4j-java)
 
 3. close all bugs on github
 4. tag the release on git
 
-5. gradle buildPython
-6. create signature using gpg (gpg -b --armor)
+5. gradle buildPython  (at py4j/py4j-java)
+6. create signature using gpg (gpg --export --armor YOUR_KEY, also refer to 'Preparing gpg key' in https://spark.apache.org/release-process.html)
 
-7. upload to PyPI using twine
+7. upload to PyPI using twine (at py4j/py4j-python). For example:
 
-8. mvn package javadoc:jar source:jar
-9. create signature for the three jar files and the pom (gpg -b --armor py4j-....jar)
-10. jar -cvf bundle.jar pom.xml ... (all files)
-11. create staging release in central (https://oss.sonatype.org Staging Upload, Upload Bundle)
-12. close release
-13. publish release
+    python setup.py sdist
+    python setup.py bdist_wheel --universal
+    twine upload dist/*
 
-14. gradle updateSite
-15. Extract and modify artifacts.xml and content.xml to change build path to:
+8. make sure you have 'settings.xml' under '~/.m2', see also https://central.sonatype.org/publish/publish-maven/#distribution-management-and-authentication
+9. if you are a new user in Sonatype, you should replace the upload URL in pom.xml (at py4j/py4j-java). For example:
+
+    # In Mac
+    sed -i '' 's/oss.sonatype.org/s01.oss.sonatype.org/g' pom.xml
+    # or in Linux OS
+    sed 's/oss.sonatype.org/s01.oss.sonatype.org/g' pom.xml
+
+10. mvn clean deploy (at py4j/py4j-java)
+
+11. gradle updateSite
+12. Extract and modify artifacts.xml and content.xml to change build path to:
     1. Py4J p2 Repository (repository name in artifacts and content)
     2. version.Py4J (unit name and provides name in content)
-16. jar -cf content.jar content.xml
-17. jar -cf artifacts artifacts.xml
-18. Create a release with bintray
-19. Create a zip file with the version (e.g., 0.10.0.zip)
-20. Upload release
-21. Update symbolic links of eclipse.py4j.org to point to latest release.
+13. jar -cf content.jar content.xml
+14. jar -cf artifacts artifacts.xml
+15. Create a release with bintray
+16. Create a zip file with the version (e.g., 0.10.0.zip)
+17. Upload release
+18. Update symbolic links of eclipse.py4j.org to point to latest release.
 
-22. send an email to the mailing list.
+19. send an email to the mailing list.


### PR DESCRIPTION
This PR proposes two:

- Improve the release process with leveraging Maven plugin that automates GPG-sign, releasing it in the Sonatype repository, etc.
- Improve the release process
  - Added a bit of guides on how to generate GPG
  - Added some example commands for PyPI release
