### PR TITLE
Add support for Java 17.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,16 +14,16 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-18.04, windows-2019 ]
-        java-version: [ 8 ]
+        java-version: [ 8, 11, 17 ]
         python-version: [ '2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10' ]
     name: Py ${{ matrix.python-version }}, Java ${{ matrix.java-version }}, ${{ matrix.os }}
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # pin@v2.3.5
 
-      - name: Setup Java ${{ matrix.java-version}} JDK
+      - name: Setup Java 8 JDK for build
         uses: actions/setup-java@8db439b6b47e5e12312bf036760bbaa6893481ac #pin@v2.3.1
         with:
-          java-version: '${{ matrix.java-version }}'
+          java-version: '8'
           distribution: 'adopt'
           cache: 'gradle'
 
@@ -58,9 +58,19 @@ jobs:
           ./gradlew check
           ./gradlew assemble
 
+      - name: Setup Java ${{ matrix.java-version }} JDK for PyTest
+        if: ${{ matrix.java-version != '8' }}
+        uses: actions/setup-java@8db439b6b47e5e12312bf036760bbaa6893481ac #pin@v2.3.1
+        with:
+          java-version: '${{ matrix.java-version }}'
+          distribution: 'adopt'
+          cache: 'gradle'
+
       - name: Run PyTest
         run: |
           cd py4j-python
+          echo `java -version`
+          echo $JAVA_HOME
           # Java TLS tests are disabled until they can be fixed (refs #441)
           pytest -k "not java_tls_test."
 

--- a/py4j-java/src/main/java/py4j/reflection/MethodInvoker.java
+++ b/py4j-java/src/main/java/py4j/reflection/MethodInvoker.java
@@ -237,13 +237,13 @@ public class MethodInvoker {
 			if (method != null) {
 				AccessController.doPrivileged(new PrivilegedAction<Object>() {
 					public Object run() {
-						method.trySetAccessible();
+						ReflectionShim.trySetAccessible(method);
 						return null;
 					}
 				});
 				returnObject = method.invoke(obj, newArguments);
 			} else if (constructor != null) {
-				constructor.trySetAccessible();
+				ReflectionShim.trySetAccessible(constructor);
 				returnObject = constructor.newInstance(newArguments);
 			}
 		} catch (InvocationTargetException ie) {

--- a/py4j-java/src/main/java/py4j/reflection/ReflectionEngine.java
+++ b/py4j-java/src/main/java/py4j/reflection/ReflectionEngine.java
@@ -202,8 +202,9 @@ public class ReflectionEngine {
 
 		for (Constructor<?> constructor : clazz.getConstructors()) {
 			if (constructor.getParameterTypes().length == length) {
-				if (constructor.trySetAccessible())
+				if (ReflectionShim.trySetAccessible(constructor)) {
 					methods.add(constructor);
+				}
 			}
 		}
 
@@ -344,16 +345,11 @@ public class ReflectionEngine {
 	private List<Method> getMethodsByNameAndLength(Class<?> clazz, String name, int length) {
 		List<Method> methodsToCheck = new ArrayList<Method>();
 
-		while (true) {
+		while (clazz != null) {
 			methodsToCheck.addAll(Arrays.asList(clazz.getDeclaredMethods()));
 			for (Class<?> intf : clazz.getInterfaces()) {
 				methodsToCheck.addAll(Arrays.asList(intf.getDeclaredMethods()));
 			}
-
-			if (clazz == Object.class) {
-				break;
-			}
-
 			clazz = clazz.getSuperclass();
 		}
 
@@ -363,15 +359,11 @@ public class ReflectionEngine {
 			if (method.getName().equals(name) && method.getParameterTypes().length == length) {
 				// If it can't be set to accessible, there is
 				// not much we can do, other than look further.
-				if (method.trySetAccessible()) {
+				if (ReflectionShim.trySetAccessible(method)) {
 					methods.add(method);
 				}
 			}
 		}
-
-		// So the most generic ones come first, assuming they
-		// are the most accessible, even across modules.
-		Collections.reverse(methods);
 
 		return methods;
 	}

--- a/py4j-java/src/main/java/py4j/reflection/ReflectionShim.java
+++ b/py4j-java/src/main/java/py4j/reflection/ReflectionShim.java
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * Copyright (c) 2009-2022, Barthelemy Dagenais and individual contributors.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * - The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+package py4j.reflection;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ReflectionShim {
+
+	private static Method trySetAccessible;
+
+	static {
+		try {
+			trySetAccessible = AccessibleObject.class.getDeclaredMethod("trySetAccessible");
+		} catch (NoSuchMethodException e) {
+			trySetAccessible = null;
+		}
+	}
+
+	/**
+	 * If there is `trySetAccessible` method defined in `AccessibleObject`, it should be used;
+	 * otherwise, fallback to `setAccessible`.
+	 */
+	public static boolean trySetAccessible(AccessibleObject accessibleObject) {
+		if (trySetAccessible != null) {
+			try {
+				return (Boolean) trySetAccessible.invoke(accessibleObject);
+			} catch (IllegalAccessException e) {
+				// won't happen.
+				throw new AssertionError(e);
+			} catch (InvocationTargetException e) {
+				// won't happen.
+				throw new AssertionError(e);
+			}
+		} else {
+			accessibleObject.setAccessible(true);
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
Based on #453, introduces `ReflectionShim` for older versions of JDK that don't have `AccessibleObject.trySetAccessible` to fallback to `setAccessible`.

Resolves #485.