### PR TITLE
Detach Java objects only when _detach method exists

### DIFF
--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -1305,7 +1305,8 @@ class JavaMember(object):
             answer, self.gateway_client, self.target_id, self.name)
 
         for temp_arg in temp_args:
-            temp_arg._detach()
+            if hasattr(temp_arg, "_detach"):
+                temp_arg._detach()
 
         return connection
 
@@ -1322,7 +1323,8 @@ class JavaMember(object):
             answer, self.gateway_client, self.target_id, self.name)
 
         for temp_arg in temp_args:
-            temp_arg._detach()
+            if hasattr(temp_arg, "_detach"):
+                temp_arg._detach()
 
         return return_value
 
@@ -1586,7 +1588,8 @@ class JavaClass(object):
             answer, self._gateway_client, None, self._fqn)
 
         for temp_arg in temp_args:
-            temp_arg._detach()
+            if hasattr(temp_arg, "_detach"):
+                temp_arg._detach()
 
         return return_value
 


### PR DESCRIPTION
This is more a bug or safeguard.

After conversion of arguments (via our `Converter.convert` interface in Py4J), the returned argument might not be a plain `JavaObject`. For example, `JavaObject(java.lang.Integer)` would be converted to `int` automatically, see also https://github.com/py4j/py4j/issues/163.

However, the current codebase requires it to be a `JavaObject` by assuming `_detach` method exists (to garbage collect the instance). In fact, calling a Java method with these Python primitives are valid in Py4J, so it makes sense to allow passing returning primitive types via `Converter.convert`.

Therefore, this PR proposes to call `_detach` only when it exists, and delegates the type checking into actual method invocation that is consistent with calling the usual JVM methods via Py4J.

I manually tested, and will add the integration test into PySpark side. It's a bit tricky to add a unittest, and it will be tested together with PySpark.

See also https://github.com/apache/spark/pull/32955#discussion_r658315864