### PR TITLE
Reduce test combinations to one Windows, one JDK 11 and one JDK 17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,19 @@ jobs:
     runs-on: '${{ matrix.os }}'
     strategy:
       matrix:
-        os: [ ubuntu-18.04, windows-2019 ]
-        java-version: [ 8, 11, 17 ]
+        os: [ ubuntu-18.04 ]
+        java-version: [ 8 ]
         python-version: [ '2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        include:
+          - os: windows-2019
+            java-version: 17
+            python-version: '3.10'
+          - os: ubuntu-18.04
+            java-version: 11
+            python-version: '2.7'
+          - os: ubuntu-18.04
+            java-version: 17
+            python-version: '3.8'
     name: Py ${{ matrix.python-version }}, Java ${{ matrix.java-version }}, ${{ matrix.os }}
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # pin@v2.3.5


### PR DESCRIPTION
Windows test is too flaky, and we now create a super lot of jobs because of JDK combinations.
This PR reduces the number of tests to one Windows, one JDK 11 and one JDK 17