### PR TITLE
Give py4j thread an explicit name, mark them as daemon

### DIFF
--- a/py4j-java/src/main/java/py4j/ClientServerConnection.java
+++ b/py4j-java/src/main/java/py4j/ClientServerConnection.java
@@ -97,7 +97,7 @@ public class ClientServerConnection implements Py4JServerConnection, Py4JClientC
 	}
 
 	public void startServerConnection() throws IOException {
-		Thread t = new Thread(this);
+		Thread t = ThreadUtil.createThread(this);
 		t.start();
 	}
 

--- a/py4j-java/src/main/java/py4j/GatewayConnection.java
+++ b/py4j-java/src/main/java/py4j/GatewayConnection.java
@@ -156,7 +156,7 @@ public class GatewayConnection implements Runnable, Py4JServerConnection {
 	 * <p>Wraps the GatewayConnection in a thread and start the thread.</p>
 	 */
 	public void startConnection() {
-		Thread t = new Thread(this);
+		Thread t = ThreadUtil.createThread(this);
 		t.start();
 	}
 

--- a/py4j-java/src/main/java/py4j/GatewayServer.java
+++ b/py4j-java/src/main/java/py4j/GatewayServer.java
@@ -763,7 +763,7 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 		startSocket();
 
 		if (fork) {
-			Thread t = new Thread(this);
+			Thread t = ThreadUtil.createThread(this);
 			t.start();
 		} else {
 			run();

--- a/py4j-java/src/main/java/py4j/ThreadUtil.java
+++ b/py4j-java/src/main/java/py4j/ThreadUtil.java
@@ -1,0 +1,31 @@
+package py4j;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * <p>
+ * Thread utility class providing a method to create threads.
+ * </p>
+ *
+ * @author Alex Archambault
+ *
+ */
+public class ThreadUtil {
+
+    private static ThreadFactory factory = new ThreadFactory() {
+        private final AtomicInteger counter = new AtomicInteger();
+        @Override
+        public Thread newThread(Runnable r) {
+            int index = counter.incrementAndGet();
+            String name = "py4j-" + index;
+            Thread thread = new Thread(r, name);
+            thread.setDaemon(true);
+            return thread;
+        }
+    };
+
+    public static Thread createThread(Runnable runnable) {
+        return factory.newThread(runnable);
+    }
+}


### PR DESCRIPTION
This PR makes py4j give more explicit names to the threads it creates (like `py4j-…` rather than the default `Thread-…`), which makes it easier to inspect JVM processes where py4j is running.

It also [marks those threads as daemon](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#setDaemon-boolean-), so that exiting the main thread of the JVM, by reaching the end of the `main` method, actually makes the JVM exit (provided no other non-daemon threads were created by users).