### PR TITLE
Add TypeInt for Specifying Integer Variant from Python to Java

### DIFF
--- a/py4j-python/src/py4j/protocol.py
+++ b/py4j-python/src/py4j/protocol.py
@@ -21,6 +21,8 @@ from __future__ import unicode_literals, absolute_import
 from base64 import standard_b64encode, standard_b64decode
 
 from decimal import Decimal
+from enum import Enum
+from typing import NamedTuple
 
 from py4j.compat import (
     long, basestring, unicode, bytearray2,
@@ -69,6 +71,14 @@ NO_MEMBER = "o"
 VOID_TYPE = "v"
 ITERATOR_TYPE = "g"
 PYTHON_PROXY_TYPE = "f"
+
+class JavaType(Enum):
+    PRIMITIVE_INT = INTEGER_TYPE
+    PRIMITIVE_LONG = LONG_TYPE
+
+class TypeInt(NamedTuple):
+    value: int
+    java_type: JavaType
 
 # Protocol
 END = "e"
@@ -277,6 +287,8 @@ def get_command_part(parameter, python_proxy_pool=None):
         command_part = BOOLEAN_TYPE + smart_decode(parameter)
     elif isinstance(parameter, Decimal):
         command_part = DECIMAL_TYPE + smart_decode(parameter)
+    elif isinstance(parameter, TypeInt):
+        command_part = parameter.java_type.value + smart_decode(parameter.value)
     elif isinstance(parameter, int) and parameter <= JAVA_MAX_INT\
             and parameter >= JAVA_MIN_INT:
         command_part = INTEGER_TYPE + smart_decode(parameter)


### PR DESCRIPTION
This PR addresses issue #374. It provides a way for users to specify how they would like Python integers to be converted into Java (whether to treat them like an int, short, or long). This PR currently only adds an integer and long variant, since Py4J does not have general support for shorts.