### PR TITLE
fixes #507 -- Fix GitHub workflow badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ documentation fixes. Please visit the `contributing guide
 <https://www.py4j.org/contributing.html>`_ for more
 information.
 
-.. image:: https://img.shields.io/github/workflow/status/bartdag/py4j/test.svg
-    :target: https://github.com/bartdag/py4j/actions/workflows/test.yml
+.. image:: https://img.shields.io/github/actions/workflow/status/py4j/py4j/test.yml.svg
+    :target: https://github.com/py4j/py4j/actions/workflows/test.yml
 
 .. image:: https://img.shields.io/pypi/l/py4j.svg
 


### PR DESCRIPTION
Fixes #507

old rendering:

![Screenshot 2023-02-10 at 13 08 17](https://user-images.githubusercontent.com/20516159/218099873-6eecde66-8796-430f-b91e-2abfece4917b.png)


new rendering of badge:

![Screenshot 2023-02-10 at 13 21 31](https://user-images.githubusercontent.com/20516159/218102310-cdf6fb02-b3f8-4c96-b992-8ad366c15bcb.png)

See the linked GitHub issue from the previous version of the badge: https://github.com/badges/shields/issues/8671

In summary, this badge was changed in a breaking fashion such that the badge was just linking to the github issue rather than showing the data. Updating the url resolves this.

I also updated to using py4j as the GitHub user.


