### PR TITLE
fixes #511 -- Support Exposing JVM Debug Port

### DIFF
--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -334,7 +334,13 @@ def launch_gateway(port=0, jarpath="", classpath="", javaopts=[],
 
     # Determine which port the server started on (needed to support
     # ephemeral ports)
-    _port = int(proc.stdout.readline())
+    _port = None
+    while _port is None:
+        try:
+            _port = int(proc.stdout.readline())
+        except ValueError:
+            # If a JVM debug port is exposed, its details will be printed first
+            pass
 
     # Read the auth token from the server if enabled.
     _auth_token = None

--- a/py4j-python/src/py4j/tests/java_gateway_test.py
+++ b/py4j-python/src/py4j/tests/java_gateway_test.py
@@ -1075,6 +1075,14 @@ class GatewayLauncherTest(unittest.TestCase):
         self.gateway = JavaGateway.launch_gateway(javaopts=["-Xmx64m"])
         self.assertTrue(self.gateway.jvm)
 
+    def testJvmDebugPort(self):
+        from random import randint
+        dport = randint(5000, 5999)
+        self.gateway = JavaGateway.launch_gateway(javaopts=[
+            "-agentlib:jdwp=transport=dt_socket,"
+            f"server=y,suspend=n,address=*:{dport}"])
+        self.assertTrue(self.gateway.jvm)
+
     def testCwd(self):
         parent_directory = os.path.dirname(os.getcwd())
         self.gateway = JavaGateway.launch_gateway(cwd=parent_directory)


### PR DESCRIPTION
When users expose JVM debug ports, the JVM prints information about the debug port on initialization (ie before `main` is invoked). Discard stdout noise until the port is successfully read.