### PR TITLE
Improve Py4j command cancellation by shutting down the JVM side of the socket

### DIFF
--- a/py4j-java/src/main/java/py4j/GatewayConnection.java
+++ b/py4j-java/src/main/java/py4j/GatewayConnection.java
@@ -47,6 +47,7 @@ import java.util.logging.Logger;
 import py4j.commands.ArrayCommand;
 import py4j.commands.AuthCommand;
 import py4j.commands.CallCommand;
+import py4j.commands.CancelCommand;
 import py4j.commands.Command;
 import py4j.commands.ConstructorCommand;
 import py4j.commands.DirCommand;
@@ -103,6 +104,7 @@ public class GatewayConnection implements Runnable, Py4JServerConnection {
 		baseCommands.add(MemoryCommand.class);
 		baseCommands.add(ReflectionCommand.class);
 		baseCommands.add(ShutdownGatewayServerCommand.class);
+		baseCommands.add(CancelCommand.class);
 		baseCommands.add(JVMViewCommand.class);
 		baseCommands.add(ExceptionCommand.class);
 		baseCommands.add(DirCommand.class);

--- a/py4j-java/src/main/java/py4j/GatewayServer.java
+++ b/py4j-java/src/main/java/py4j/GatewayServer.java
@@ -707,8 +707,8 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 			lock.lock();
 			ArrayList<Py4JServerConnection> tempConnections = new ArrayList<Py4JServerConnection>(connections);
 			for (Py4JServerConnection connection : tempConnections) {
-				if (connection.getSocket() != null &&
-						(connection.getSocket().getPort() == remotePort || connection.getSocket().getLocalPort() == localPort)) {
+				if (connection.getSocket() != null && (connection.getSocket().getPort() == remotePort
+						|| connection.getSocket().getLocalPort() == localPort)) {
 					connection.shutdown();
 					connections.remove(connection);
 				}

--- a/py4j-java/src/main/java/py4j/GatewayServer.java
+++ b/py4j-java/src/main/java/py4j/GatewayServer.java
@@ -702,6 +702,22 @@ public class GatewayServer extends DefaultGatewayServerListener implements Py4JJ
 		this.shutdown(true);
 	}
 
+	public void shutdownSocket(String address, int remotePort, int localPort) {
+		try {
+			lock.lock();
+			ArrayList<Py4JServerConnection> tempConnections = new ArrayList<Py4JServerConnection>(connections);
+			for (Py4JServerConnection connection : tempConnections) {
+				if (connection.getSocket() != null &&
+						(connection.getSocket().getPort() == remotePort || connection.getSocket().getLocalPort() == localPort)) {
+					connection.shutdown();
+					connections.remove(connection);
+				}
+			}
+		} finally {
+			lock.unlock();
+		}
+	}
+
 	/**
 	 * <p>
 	 * Stops accepting connections, closes all current connections, and calls

--- a/py4j-java/src/main/java/py4j/Py4JJavaServer.java
+++ b/py4j-java/src/main/java/py4j/Py4JJavaServer.java
@@ -79,6 +79,11 @@ public interface Py4JJavaServer {
 	 */
 	void shutdown(boolean shutdownCallbackClient);
 
+	/**
+	 * Shuts down the socket that matches address, remote port, and local port.
+	 */
+	void shutdownSocket(String address, int remotePort, int localPort);
+
 	void addListener(GatewayServerListener listener);
 
 	/**

--- a/py4j-java/src/main/java/py4j/commands/CancelCommand.java
+++ b/py4j-java/src/main/java/py4j/commands/CancelCommand.java
@@ -1,0 +1,75 @@
+/******************************************************************************
+ * Copyright (c) 2009-2022, Barthelemy Dagenais and individual contributors.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * - The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+package py4j.commands;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+
+import py4j.Gateway;
+import py4j.GatewayServer;
+import py4j.Py4JException;
+import py4j.Py4JJavaServer;
+import py4j.Py4JServerConnection;
+
+/**
+ * <p>
+ * The CancelCommand is responsible for cancelling the command on the server and shutting
+ * down the associated socket in JVM.
+ * </p>
+ */
+public class CancelCommand extends AbstractCommand {
+	private Py4JJavaServer gatewayServer;
+
+	public CancelCommand() {
+		super();
+		this.commandName = "z";
+	}
+
+	@Override
+	public void execute(String commandName, BufferedReader reader, BufferedWriter writer)
+			throws Py4JException, IOException {
+		String address = reader.readLine();
+		int remotePort = Integer.parseInt(reader.readLine());
+		int localPort = Integer.parseInt(reader.readLine());
+		if (this.gatewayServer != null) {
+			this.gatewayServer.shutdownSocket(address, remotePort, localPort);
+		}
+	}
+
+	@Override
+	public void init(Gateway gateway, Py4JServerConnection connection) {
+		super.init(gateway, connection);
+		Object serverObj = gateway.getObject(GatewayServer.GATEWAY_SERVER_ID);
+		if (serverObj != null && serverObj instanceof Py4JJavaServer) {
+			this.gatewayServer = (Py4JJavaServer) serverObj;
+		}
+	}
+}

--- a/py4j-java/src/test/java/py4j/commands/CancelCommandTest.java
+++ b/py4j-java/src/test/java/py4j/commands/CancelCommandTest.java
@@ -1,0 +1,101 @@
+/******************************************************************************
+ * Copyright (c) 2009-2022, Barthelemy Dagenais and individual contributors.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * - The name of the author may not be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *****************************************************************************/
+package py4j.commands;
+
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import py4j.Gateway;
+import py4j.GatewayServer;
+import py4j.Py4JJavaServer;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class CancelCommandTest {
+	private Gateway gateway;
+	private BufferedWriter writer;
+	private StringWriter sWriter;
+
+	@Before
+	public void setUp() {
+		gateway = spy(new Gateway(null));
+		gateway.startup();
+		sWriter = new StringWriter();
+		writer = new BufferedWriter(sWriter);
+	}
+
+	@After
+	public void tearDown() {
+		gateway.shutdown();
+	}
+
+	@Test
+	public void testCancelCommandGatewayServerIsNull() {
+		try {
+			doReturn(null).when(gateway).getObject(GatewayServer.GATEWAY_SERVER_ID);
+			CancelCommand command = new CancelCommand();
+			command.init(gateway, null);
+			// Should not fail with NullPointerException.
+			command.execute("z", new BufferedReader(new StringReader("address\n1000\n2000")), writer);
+			verify(gateway, times(1)).getObject(GatewayServer.GATEWAY_SERVER_ID);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+
+	@Test
+	public void testCancelCommand() {
+		try {
+			Py4JJavaServer server = mock(Py4JJavaServer.class);
+			doReturn(server).when(gateway).getObject(GatewayServer.GATEWAY_SERVER_ID);
+			CancelCommand command = new CancelCommand();
+			command.init(gateway, null);
+			command.execute("z", new BufferedReader(new StringReader("address\n1000\n2000")), writer);
+			verify(gateway, times(1)).getObject(GatewayServer.GATEWAY_SERVER_ID);
+			verify(server, times(1)).shutdownSocket("address", 1000, 2000);
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail();
+		}
+	}
+}


### PR DESCRIPTION
This PR improves PySpark command cancellation by shutting down the JVM side of the connection:
- JVM thread is shut down.
- All of the Py4j connections that are related to the local or remote port are also shut down.

The idea is to find all of the open sockets in JVM on KeyboardInterrupt and then send the special "CancelCommand" with local and remote ports to cancel the matching socket in JVM. This helps to cancel commands in a notebook correctly in cases when the Java side executes code asynchronously. In those cases, I found KeyboardInterrupt only terminates the Python side of the connection.

