### PR TITLE
Fix typo in advanced_topics docs (clause -> cause)

### DIFF
--- a/py4j-web/advanced_topics.rst
+++ b/py4j-web/advanced_topics.rst
@@ -757,7 +757,7 @@ possible to catch all related Py4J errors with one except clause:
     traceback.print_exc()
 
 If a Py4J Exception wraps another exception, the original exception will be
-available in the ``clause`` field.
+available in the :attr:`cause <py4j.protocol.Py4JError.cause>` field.
 
 
 .. code-block:: python
@@ -1185,5 +1185,3 @@ The following chart illustrates the progress Py4J made so far for transferring
 
     <iframe width="600" height="371" seamless frameborder="0" scrolling="no"
     src="https://docs.google.com/spreadsheets/d/14ljMYIESFbOBFe4o_Fy6WirI2P5iCQuTP9fA1BuLMAI/pubchart?oid=935988429&amp;format=interactive"></iframe>
-
-


### PR DESCRIPTION
The advanced_topics page previously referred to [`Py4JError`](https://www.py4j.org/py4j_java_protocol.html#py4j.protocol.Py4JError)'s `clause` attribute, which is a misspelling of the `cause` attribute. This PR fixes the misspelling.

This also changes the formatting of the attribute to link to its docs rather than just code formatting (though since the docs for the `cause` attribute don't exist, no hyperlink is actually created in the html).

Before (live at https://www.py4j.org/advanced_topics.html):

![image](https://github.com/py4j/py4j/assets/16820980/0af7719f-2d09-48a1-8277-c7fae5903a50)

After (built locally):
 
![image](https://github.com/py4j/py4j/assets/16820980/d078d181-1121-43a5-b13e-a9872edea876)
