### PR TITLE
Add method to terminate JVM process

### DIFF
--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -2131,7 +2131,35 @@ class JavaGateway(object):
         """
         return gateway_help(
             self._gateway_client, var, pattern, short_name, display)
+    
+    def terminate_jvm(self, exit_code=0, raise_exception=False):
+        """ Terminating the Java process and breaking the connection with it
 
+        :param exit_code: Java process exit code
+
+        :param raise_exception: If `True`, raise an exception if an error
+            occurs while terminating Java process (very likely with sockets).
+        """
+
+        try:
+            sys_exit_jvm = self.jvm.System.exit
+            sys_exit_jvm_args = sys_exit_jvm._build_args(exit_code)[0]
+            command_to_exit_jvm = proto.CALL_COMMAND_NAME +\
+                sys_exit_jvm.command_header + sys_exit_jvm_args +\
+                proto.END_COMMAND_PART
+            self._gateway_client.send_terminate_command()
+            gateway_connection = self._gateway_client._get_connection()
+            gateway_socket = gateway_connection.socket
+            gateway_socket.sendall(command_to_exit_jvm)
+        except Exception:
+            if raise_exception:
+                raise
+            else:
+                logger.info(
+                    "Exception while terminating Java process",
+                    exc_info=True)
+        self.shutdown()
+            
     @classmethod
     def launch_gateway(
             cls, port=0, jarpath="", classpath="", javaopts=[],

--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -2150,7 +2150,7 @@ class JavaGateway(object):
             self._gateway_client.send_terminate_command()
             gateway_connection = self._gateway_client._get_connection()
             gateway_socket = gateway_connection.socket
-            gateway_socket.sendall(command_to_exit_jvm)
+            gateway_socket.sendall(command_to_exit_jvm.encode("utf-8"))
         except Exception:
             if raise_exception:
                 raise


### PR DESCRIPTION
I use Payspark in my work, which uses py4j to connect PVM and JVM processes. 
I often need to restart the Spark JVM driver process and redefine the amount of memory for it. The existing methods do not ensure the completion of the JVM process. The only way to achieve this is to complete the Python process, which we cannot afford.

The current PR adds a new method to the JavaGateway class, which will allow JVM processes to terminate. Its logic is to call System.exit() on the JVM side without waiting for a return response.

These changes are based on an article (in Russian) where the current problem was fixed manually.
Article: https://habr.com/ru/companies/sberbank/articles/805285