### PR TITLE
[TESTS-ONLY] Fix Flaky `GatewayServerTest`

### DIFF
--- a/py4j-java/src/test/java/py4j/GatewayServerTest.java
+++ b/py4j-java/src/test/java/py4j/GatewayServerTest.java
@@ -199,8 +199,11 @@ public class GatewayServerTest {
 			// Throw an IOException since that's what the test above expects in this case.
 			throw new IOException("Auth unsuccessful.");
 		} else {
-			assertTrue(Protocol.isReturnMessage(reply));
-			if (Protocol.isError(reply.substring(1))) {
+			assertTrue(
+				"Expected return message or null, got: " + reply,
+				reply == null || Protocol.isReturnMessage(reply)
+			);
+			if (reply == null || Protocol.isError(reply.substring(1))) {
 				throw new IOException("Error from server.");
 			}
 		}

--- a/py4j-java/src/test/java/py4j/GatewayServerTest.java
+++ b/py4j-java/src/test/java/py4j/GatewayServerTest.java
@@ -199,10 +199,8 @@ public class GatewayServerTest {
 			// Throw an IOException since that's what the test above expects in this case.
 			throw new IOException("Auth unsuccessful.");
 		} else {
-			assertTrue(
-				"Expected return message or null, got: " + reply,
-				reply == null || Protocol.isReturnMessage(reply)
-			);
+			assertTrue("Expected return message or null, got: " + reply,
+					reply == null || Protocol.isReturnMessage(reply));
 			if (reply == null || Protocol.isError(reply.substring(1))) {
 				throw new IOException("Error from server.");
 			}


### PR DESCRIPTION
- This PR fixes the GatewayServerTest to handle a race condition in the GatewayServer's handling of connections with invalid secrets.
- The server may either return an appropriate error message (this is what the test expected pre-patch) or the server may return no response (which becomes a `null` response)
- The test-case is updated to accept both responses as valid