### PR TITLE
#379 Timeout for starting Java process in launch_gateway

### DIFF
--- a/py4j-java/src/main/java/py4j/CallbackClient.java
+++ b/py4j-java/src/main/java/py4j/CallbackClient.java
@@ -81,7 +81,7 @@ public class CallbackClient implements Py4JPythonClient {
 
 	public final static TimeUnit DEFAULT_MIN_CONNECTION_TIME_UNIT = TimeUnit.SECONDS;
 
-	private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+	private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1, new DaemonThreadFactory("py4j-callback-client-cleaner"));
 
 	protected final long minConnectionTime;
 

--- a/py4j-java/src/main/java/py4j/DaemonThreadFactory.java
+++ b/py4j-java/src/main/java/py4j/DaemonThreadFactory.java
@@ -1,0 +1,20 @@
+package py4j;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DaemonThreadFactory implements ThreadFactory {
+    private final String threadNamePrefix;
+    private final AtomicInteger counter = new AtomicInteger();
+
+    public DaemonThreadFactory(String threadNamePrefix) {
+        this.threadNamePrefix = threadNamePrefix;
+    }
+
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(r);
+        t.setDaemon(true);
+        t.setName(this.threadNamePrefix + "-" + this.counter.getAndIncrement());
+        return t;
+    }
+}


### PR DESCRIPTION
Make CallbackClient to use daemon thread so it does not prevent GatewayServer from exit

I observed the same issue as in #379

Quick investigation shown that Java Process did not exit and the only non-daemon thread was pool thread

```
"pool-1-thread-1" #13 prio=5 os_prio=31 cpu=3.68ms elapsed=72.09s tid=0x00007fd38b144800 nid=0x7403 waiting on condition  [0x000070000574e000]
   java.lang.Thread.State: TIMED_WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@11.0.23/Native Method)
	- parking to wait for  <0x000000070f22e028> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@11.0.23/LockSupport.java:234)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.awaitNanos(java.base@11.0.23/AbstractQueuedSynchronizer.java:2123)
	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.23/ScheduledThreadPoolExecutor.java:1182)
	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@11.0.23/ScheduledThreadPoolExecutor.java:899)
	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@11.0.23/ThreadPoolExecutor.java:1054)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@11.0.23/ThreadPoolExecutor.java:1114)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@11.0.23/ThreadPoolExecutor.java:628)
	at java.lang.Thread.run(java.base@11.0.23/Thread.java:829)
```

This PR makes pool to create daemon thread so this will not prevent failed JVM from exiting