### PR TITLE
Retry Py4J on empty response

### DIFF
--- a/py4j-python/src/py4j/clientserver.py
+++ b/py4j-python/src/py4j/clientserver.py
@@ -561,7 +561,7 @@ class ClientServerConnection(object):
                             proto.ERROR_RETURN_MESSAGE.encode("utf-8"))
         except Exception as e:
             logger.info("Error while receiving.", exc_info=True)
-            if isinstance(e, Py4JNetworkError):
+            if isinstance(e, Py4JNetworkError) and e.when == proto.EMPTY_RESPONSE:
                 raise
             raise Py4JNetworkError(
                 "Error while sending or receiving", e, proto.ERROR_ON_RECEIVE)

--- a/py4j-python/src/py4j/clientserver.py
+++ b/py4j-python/src/py4j/clientserver.py
@@ -561,6 +561,8 @@ class ClientServerConnection(object):
                             proto.ERROR_RETURN_MESSAGE.encode("utf-8"))
         except Exception as e:
             logger.info("Error while receiving.", exc_info=True)
+            if isinstance(e, Py4JNetworkError):
+                raise
             raise Py4JNetworkError(
                 "Error while sending or receiving", e, proto.ERROR_ON_RECEIVE)
 

--- a/py4j-python/src/py4j/clientserver.py
+++ b/py4j-python/src/py4j/clientserver.py
@@ -537,7 +537,8 @@ class ClientServerConnection(object):
                 # Happens when a the other end is dead. There might be an empty
                 # answer before the socket raises an error.
                 if answer.strip() == "":
-                    raise Py4JNetworkError("Answer from Java side is empty")
+                    raise Py4JNetworkError(
+                        "Answer from Java side is empty", when=proto.EMPTY_RESPONSE)
                 if answer.startswith(proto.RETURN_MESSAGE):
                     return answer[1:]
                 else:

--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -1263,7 +1263,7 @@ class GatewayConnection(object):
             return answer
         except Exception as e:
             logger.info("Error while receiving.", exc_info=True)
-            if isinstance(e, Py4JNetworkError):
+            if isinstance(e, Py4JNetworkError) and e.when == proto.EMPTY_RESPONSE:
                 raise
             raise Py4JNetworkError(
                 "Error while receiving", e, proto.ERROR_ON_RECEIVE)

--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -1263,6 +1263,8 @@ class GatewayConnection(object):
             return answer
         except Exception as e:
             logger.info("Error while receiving.", exc_info=True)
+            if isinstance(e, Py4JNetworkError):
+                raise
             raise Py4JNetworkError(
                 "Error while receiving", e, proto.ERROR_ON_RECEIVE)
 

--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -1107,7 +1107,7 @@ class GatewayClient(object):
         return GatewayConnectionGuard(self, connection)
 
     def _should_retry(self, retry, connection, pne=None):
-        return pne and pne.when == proto.ERROR_ON_SEND or pne.when == proto.EMPTY_RESPONSE
+        return pne and (pne.when == proto.ERROR_ON_SEND or pne.when == proto.EMPTY_RESPONSE)
 
     def close(self):
         """Closes all currently opened connections.

--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -1107,7 +1107,7 @@ class GatewayClient(object):
         return GatewayConnectionGuard(self, connection)
 
     def _should_retry(self, retry, connection, pne=None):
-        return pne and pne.when == proto.ERROR_ON_SEND
+        return pne and pne.when == proto.ERROR_ON_SEND or pne.when == proto.EMPTY_RESPONSE
 
     def close(self):
         """Closes all currently opened connections.
@@ -1254,7 +1254,7 @@ class GatewayConnection(object):
             # Happens when a the other end is dead. There might be an empty
             # answer before the socket raises an error.
             if answer.strip() == "":
-                raise Py4JNetworkError("Answer from Java side is empty")
+                raise Py4JNetworkError("Answer from Java side is empty", when=proto.EMPTY_RESPONSE)
             return answer
         except Exception as e:
             logger.info("Error while receiving.", exc_info=True)

--- a/py4j-python/src/py4j/protocol.py
+++ b/py4j-python/src/py4j/protocol.py
@@ -172,6 +172,7 @@ INPUT_CONVERTER = []
 # ERRORS
 ERROR_ON_SEND = "on_send"
 ERROR_ON_RECEIVE = "on_receive"
+EMPTY_RESPONSE = "empty_response"
 
 
 def escape_new_line(original):


### PR DESCRIPTION
This PR retries Py4J on empty response. The other end might not be dead but the JVM itself might keep running. In this case, new connection has to be made.