### PR TITLE
Iterator.next should not ignore other exceptions

### DIFF
--- a/py4j-python/src/py4j/java_collections.py
+++ b/py4j-python/src/py4j/java_collections.py
@@ -32,7 +32,7 @@ from py4j.java_gateway import JavaObject, JavaMember, get_method, JavaClass
 from py4j import protocol as proto
 from py4j.protocol import (
     Py4JError, get_command_part, get_return_value, register_input_converter,
-    register_output_converter)
+    register_output_converter, Py4JJavaError)
 
 
 class JavaIterator(JavaObject):
@@ -43,6 +43,8 @@ class JavaIterator(JavaObject):
     def __init__(self, target_id, gateway_client):
         JavaObject.__init__(self, target_id, gateway_client)
         self._next_name = "next"
+        self._is_instance_of = JavaClass(
+            "py4j.reflection.TypeUtil", gateway_client).isInstanceOf
         # To bind lifecycle of this iterator to the java iterator. To prevent
         # gc of the iterator.
 
@@ -60,6 +62,10 @@ class JavaIterator(JavaObject):
                 self._target_id, self._gateway_client)
         try:
             return self._methods[self._next_name]()
+        except Py4JJavaError as e:
+            if not self._is_instance_of("java.util.NoSuchElementException", e.java_exception):
+                raise e
+            raise StopIteration()
         except Py4JError:
             raise StopIteration()
 

--- a/py4j-python/src/py4j/tests/java_iter_test.py
+++ b/py4j-python/src/py4j/tests/java_iter_test.py
@@ -1,0 +1,36 @@
+from __future__ import unicode_literals, absolute_import
+
+import unittest
+
+from py4j.java_gateway import JavaGateway, is_instance_of
+from py4j.protocol import Py4JJavaError
+from py4j.tests.java_gateway_test import (
+    start_example_app_process, safe_shutdown, sleep)
+
+
+class IteratorTest(unittest.TestCase):
+    def setUp(self):
+        self.p = start_example_app_process()
+        self.gateway = JavaGateway()
+
+    def tearDown(self):
+        safe_shutdown(self)
+        self.p.join()
+        sleep()
+
+    def testIterator(self):
+        scanner = self.gateway.jvm.java.util.Scanner("")
+        scanner.close()
+        try:
+            next(scanner)
+            self.fail("next() should have thrown an exception")
+        except Py4JJavaError as e:
+            self.assertTrue(is_instance_of(
+                self.gateway, e.java_exception, "java.lang.IllegalStateException"))
+
+        scanner = self.gateway.jvm.java.util.Scanner("")
+        self.assertEqual(list(scanner), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
It assumes `Py4JError` should always come from the iterator termination signal `NoSuchElementException`, which is not correct. We should not assume it means the iterator is terminated