### PR TITLE
#417 -- add clear implementation and unit tests

### DIFF
--- a/py4j-python/src/py4j/java_collections.py
+++ b/py4j-python/src/py4j/java_collections.py
@@ -267,6 +267,7 @@ class JavaList(JavaObject, MutableSequence):
     def __init__(self, target_id, gateway_client):
         JavaObject.__init__(self, target_id, gateway_client)
         self.java_remove = get_method(self, "remove")
+        self.java_clear = get_method(self, "clear")
 
     def __len__(self):
         return self.size()
@@ -482,6 +483,12 @@ class JavaList(JavaObject, MutableSequence):
         success = self.java_remove(new_value)
         if not success:
             raise ValueError("java_list.remove(x): x not in java_list")
+
+    def clear(self):
+        """Remove all items from the list by calling the Java List's clear method directly.
+        By directly calling the Java List's clear method, we avoid multiple Java method calls
+        and the potential exception."""
+        self.java_clear()
 
     def __str__(self):
         return self.__repr__()

--- a/py4j-python/src/py4j/tests/java_list_test.py
+++ b/py4j-python/src/py4j/tests/java_list_test.py
@@ -318,6 +318,35 @@ class ListTest(unittest.TestCase):
         self.assertEqual(len(pList), len(jList))
         self.assertEqual(str(pList), str(jList))
 
+    def testClear(self):
+        ex = self.gateway.getNewExample()
+        jList = ex.getList(5)
+
+        # Verify initial state
+        self.assertEqual(5, len(jList))
+        # Clear the list
+        jList.clear()
+        # Verify the list is empty
+        self.assertEqual(0, len(jList))
+        # Add items after clearing to verify the list is still usable
+        jList.append("new item")
+        self.assertEqual(1, len(jList))
+        self.assertEqual("new item", jList[0])
+
+    def testClearEmpty(self):
+        """Test clear method on an empty list."""
+        ex = self.gateway.getNewExample()
+        jList = ex.getList(0)
+
+        # Verify initial state
+        self.assertEqual(0, len(jList))
+        # Clear the empty list - this would fail with the default implementation
+        # because it tries to call pop() on an empty list which causes
+        # ArrayIndexOutOfBoundsException in Java
+        jList.clear()
+        # Verify the list is still empty
+        self.assertEqual(0, len(jList))
+
     def testBinaryOp(self):
         ex = self.gateway.getNewExample()
         pList = get_list(3)


### PR DESCRIPTION
# Fix JavaList.clear implementation

This PR fixes issue #417 by implementing a proper `clear()` method for JavaList that directly calls the wrapped Java List's clear method.

## Problem

Currently, JavaList inherits MutableSequence's clear implementation, which repeatedly calls `pop()` until an IndexError is raised. This causes two issues:

1. **Performance issue**: For a list with n elements, this results in n Java method calls (one for each element), which is inefficient.

2. **Error when clearing an empty list**: When the list is empty and pop() is called, it tries to remove an element at index -1, which causes an ArrayIndexOutOfBoundsException in the Java ArrayList:

```
java.lang.ArrayIndexOutOfBoundsException: -1
	at java.util.ArrayList.elementData(ArrayList.java:422)
	at java.util.ArrayList.remove(ArrayList.java:499)
```

## Solution

This PR implements a custom `clear()` method for JavaList that directly calls the wrapped Java List's clear method. This approach:

1. Is more efficient as it only requires a single Java method call regardless of the list size
2. Avoids the ArrayIndexOutOfBoundsException when clearing an empty list
3. Follows the same pattern used in JavaSet.clear

## Changes

1. Added a reference to the Java List's clear method in JavaList.__init__
2. Implemented JavaList.clear to directly call the Java List's clear method
3. Added unit tests that verify the fix works correctly and demonstrate the issue with the original implementation