### PR TITLE
#417 -- update JavaList pop method

### DIFF
--- a/py4j-python/src/py4j/java_collections.py
+++ b/py4j-python/src/py4j/java_collections.py
@@ -443,11 +443,8 @@ class JavaList(JavaObject, MutableSequence):
     def extend(self, other_list):
         self.addAll(other_list)
 
-    def pop(self, key=None):
-        if key is None:
-            new_key = self.size() - 1
-        else:
-            new_key = self.__compute_index(key)
+    def pop(self, key=-1):
+        new_key = self.__compute_index(key)
         return self.java_remove(new_key)
 
     def index(self, value):

--- a/py4j-python/src/py4j/tests/java_list_test.py
+++ b/py4j-python/src/py4j/tests/java_list_test.py
@@ -318,6 +318,119 @@ class ListTest(unittest.TestCase):
         self.assertEqual(len(pList), len(jList))
         self.assertEqual(str(pList), str(jList))
 
+    def testPopDefault(self):
+        # Test pop() with default argument (should pop the last element)
+        ex = self.gateway.getNewExample()
+        jList = ex.getList(5)  # Creates a list with elements '0', '1', '2', '3', '4'
+        pList = get_list(5)
+        
+        # Pop the last element
+        jResult = jList.pop()
+        pResult = pList.pop()
+        
+        # Check that the popped element is correct
+        self.assertEqual(jResult, pResult)
+        # Check that the list size is reduced by 1
+        self.assertEqual(len(jList), len(pList))
+        # Check that the list contents match
+        self.assertEqual(str(jList), str(pList))
+
+    def testPopPositiveIndex(self):
+        # Test pop(index) with positive indices
+        ex = self.gateway.getNewExample()
+        jList = ex.getList(5)
+        pList = get_list(5)
+        
+        # Pop element at index 2
+        jResult = jList.pop(2)
+        pResult = pList.pop(2)
+        
+        # Check that the popped element is correct
+        self.assertEqual(jResult, pResult)
+        # Check that the list size is reduced by 1
+        self.assertEqual(len(jList), len(pList))
+        # Check that the list contents match
+        self.assertEqual(str(jList), str(pList))
+        
+        # Pop the first element
+        jResult = jList.pop(0)
+        pResult = pList.pop(0)
+        # Check that the popped element is correct
+        self.assertEqual(jResult, pResult)
+        # Check that the list size is reduced by 1
+        self.assertEqual(len(jList), len(pList))
+        # Check that the list contents match
+        self.assertEqual(str(jList), str(pList))
+
+    def testPopNegativeIndex(self):
+        # Test pop(index) with negative indices
+        ex = self.gateway.getNewExample()
+        jList = ex.getList(5)
+        pList = get_list(5)
+        
+        # Pop the last element using -1
+        jResult = jList.pop(-1)
+        pResult = pList.pop(-1)
+        
+        # Check that the popped element is correct
+        self.assertEqual(jResult, pResult)
+        # Check that the list size is reduced by 1
+        self.assertEqual(len(jList), len(pList))
+        # Check that the list contents match
+        self.assertEqual(str(jList), str(pList))
+        
+        # Pop the second-to-last element using -1 again
+        jResult = jList.pop(-1)
+        pResult = pList.pop(-1)
+        
+        # Check that the popped element is correct
+        self.assertEqual(jResult, pResult)
+        # Check that the list size is reduced by 1
+        self.assertEqual(len(jList), len(pList))
+        # Check that the list contents match
+        self.assertEqual(str(jList), str(pList))
+        
+        # Pop an element from the middle using negative index
+        jResult = jList.pop(-2)
+        pResult = pList.pop(-2)
+        
+        # Check that the popped element is correct
+        self.assertEqual(jResult, pResult)
+        # Check that the list size is reduced by 1
+        self.assertEqual(len(jList), len(pList))
+        # Check that the list contents match
+        self.assertEqual(str(jList), str(pList))
+
+    def testPopEdgeCases(self):
+        # Test edge cases for pop
+        ex = self.gateway.getNewExample()
+        jList = ex.getList(3)
+        
+        # Test popping from an empty list
+        jList.clear()
+        try:
+            jList.pop()
+            self.fa9il("Should have raised IndexError")
+        except IndexError:
+            # This is expected
+            pass
+        
+        # Test popping with an out-of-bounds index
+        jList = ex.getList(3)
+        try:
+            jList.pop(10)
+            self.fail("Should have raised IndexError")
+        except IndexError:
+            # This is expected
+            pass
+        
+        try:
+            jList.pop(-10)
+            self.fail("Should have raised IndexError")
+        except IndexError:
+            # This is expected
+            pass
+
     def testBinaryOp(self):
         ex = self.gateway.getNewExample()
         pList = get_list(3)


### PR DESCRIPTION
### Simplify `JavaList.pop` and Ensure `IndexError` on Empty Lists

---

**Summary**  
This patch refactors the `JavaList.pop` implementation to default the `key` parameter to `-1` instead of `None`, removes the special-case branch, and delegates all index handling to `__compute_index`. As a result, calling `pop()` on an empty Java list now correctly raises an `IndexError` in accordance with the `MutableSequence` contract.

---

**Related Issues**

- Lesser fix for [https://github.com/py4j/py4j/issues/417](https://github.com/py4j/py4j/issues/417)

---

**Changes**
    
    - Removes the `key is None` branch entirely.
    - Relies on `__compute_index` to translate both positive and negative indices (and to raise `IndexError` if out of bounds).
        
- **Test coverage:**  
    Added comprehensive unit tests in `java_list_test.py`:
    
    - `testPopDefault`: Verifies that `pop()` removes and returns the last element.
        
    - `testPopPositiveIndex`: Covers popping at explicit positive indices (including 0).
        
    - `testPopNegativeIndex`: Covers various negative indices (`-1`, `-2`, etc.).
        
    - `testPopEdgeCases`: Confirms that popping from an empty list or with out-of-bounds indices raises `IndexError`.
        

---

**Testing**  
All existing tests pass, and the new `testPop*` methods validate correct behavior across default, positive, negative, and edge-case scenarios.

---

**Future Considerations**

- We could remove `JavaList.pop` entirely and inherit `MutableSequence.pop`, which appears to handle all cases correctly. That approach may reduce maintenance overhead, but risks altering backward-compatibility with any custom behavior in `java_remove`.