### PR TITLE
perf: Remove Python 2 compat and optimize old calls to smart_decode

### DIFF
--- a/py4j-python/src/py4j/__init__.py
+++ b/py4j-python/src/py4j/__init__.py
@@ -1,5 +1,4 @@
 # Py4J Package
-from __future__ import absolute_import
 from . import version
 
 __version__ = version.__version__

--- a/py4j-python/src/py4j/clientserver.py
+++ b/py4j-python/src/py4j/clientserver.py
@@ -7,8 +7,6 @@ thread. For example, if a request is started in a Java UI thread and the Python
 code calls some Java code, the Java code will be executed in the UI thread.
 """
 
-from __future__ import unicode_literals, absolute_import
-
 from collections import deque
 import logging
 import socket
@@ -26,7 +24,7 @@ from py4j.java_gateway import (
     server_connection_stopped, do_client_auth, _garbage_collect_proxy)
 from py4j import protocol as proto
 from py4j.protocol import (
-    Py4JError, Py4JNetworkError, smart_decode, get_command_part,
+    Py4JError, Py4JNetworkError, get_command_part,
     get_return_value, Py4JAuthenticationError)
 
 
@@ -532,7 +530,7 @@ class ClientServerConnection(object):
 
         try:
             while True:
-                answer = smart_decode(self.stream.readline()[:-1])
+                answer = self.stream.readline()[:-1].decode("utf-8")
                 logger.debug("Answer received: {0}".format(answer))
                 # Happens when a the other end is dead. There might be an empty
                 # answer before the socket raises an error.
@@ -543,7 +541,7 @@ class ClientServerConnection(object):
                     return answer[1:]
                 else:
                     command = answer
-                    obj_id = smart_decode(self.stream.readline())[:-1]
+                    obj_id = self.stream.readline()[:-1].decode("utf-8")
 
                     if command == proto.CALL_PROXY_COMMAND_NAME:
                         return_message = self._call_proxy(obj_id, self.stream)
@@ -590,7 +588,7 @@ class ClientServerConnection(object):
         authenticated = self.python_parameters.auth_token is None
         try:
             while True:
-                command = smart_decode(self.stream.readline())[:-1]
+                command = self.stream.readline()[:-1].decode("utf-8")
                 if not authenticated:
                     # Will raise an exception if auth fails in any way.
                     authenticated = do_client_auth(
@@ -598,7 +596,7 @@ class ClientServerConnection(object):
                         self.python_parameters.auth_token)
                     continue
 
-                obj_id = smart_decode(self.stream.readline())[:-1]
+                obj_id = self.stream.readline()[:-1].decode("utf-8")
                 logger.info(
                     "Received command {0} on object id {1}".
                     format(command, obj_id))
@@ -639,7 +637,7 @@ class ClientServerConnection(object):
                 get_command_part('Object ID unknown', self.pool)
 
         try:
-            method = smart_decode(input.readline())[:-1]
+            method = input.readline()[:-1].decode("utf-8")
             params = self._get_params(input)
             return_value = getattr(self.pool[obj_id], method)(*params)
             return proto.RETURN_MESSAGE + proto.SUCCESS +\
@@ -659,11 +657,11 @@ class ClientServerConnection(object):
 
     def _get_params(self, input):
         params = []
-        temp = smart_decode(input.readline())[:-1]
+        temp = input.readline()[:-1].decode("utf-8")
         while temp != proto.END:
             param = get_return_value("y" + temp, self.java_client)
             params.append(param)
-            temp = smart_decode(input.readline())[:-1]
+            temp = input.readline()[:-1].decode("utf-8")
         return params
 
     def __del__(self):

--- a/py4j-python/src/py4j/finalizer.py
+++ b/py4j-python/src/py4j/finalizer.py
@@ -7,11 +7,7 @@ Created on Mar 7, 2010
 
 :author: Barthelemy Dagenais
 """
-from __future__ import unicode_literals, absolute_import
-
 from threading import RLock
-
-from py4j.compat import items
 
 
 class ThreadSafeFinalizer(object):
@@ -64,7 +60,7 @@ class ThreadSafeFinalizer(object):
             if clear_all:
                 cls.finalizers.clear()
             else:
-                for id, ref in items(cls.finalizers):
+                for id, ref in list(cls.finalizers.items()):
                     if ref() is None:
                         cls.finalizers.pop(id, None)
 
@@ -116,7 +112,7 @@ class Finalizer(object):
         if clear_all:
             cls.finalizers.clear()
         else:
-            for id, ref in items(cls.finalizers):
+            for id, ref in list(cls.finalizers.items()):
                 if ref() is None:
                     cls.finalizers.pop(id, None)
 

--- a/py4j-python/src/py4j/java_collections.py
+++ b/py4j-python/src/py4j/java_collections.py
@@ -8,26 +8,12 @@ Created on Jan 22, 2010
 
 :author: Barthelemy Dagenais
 """
-from __future__ import unicode_literals, absolute_import
-
-# As of Python 3.3, the abstract base classes in the collections module have
-# been moved to collections.abc.
-# (see https://docs.python.org/3.3/library/collections.abc.html)
-try:
-    # Python >=3.3
-    from collections.abc import (
-        MutableMapping, Sequence, MutableSequence,
-        MutableSet, Set)
-except ImportError:
-    # Python <=3.2
-    from collections import (
-        MutableMapping, Sequence, MutableSequence,
-        MutableSet, Set)
+from collections.abc import (
+    MutableMapping, Sequence, MutableSequence,
+    MutableSet, Set)
 import sys
 
-from py4j.compat import (
-    iteritems, next, hasattr2, isbytearray,
-    ispython3bytestr, basestring)
+from py4j.compat import hasattr2
 from py4j.java_gateway import JavaObject, JavaMember, get_method, JavaClass
 from py4j import protocol as proto
 from py4j.protocol import (
@@ -105,7 +91,7 @@ class JavaMap(JavaObject, MutableMapping):
     def __repr__(self):
         items = (
             "{0}: {1}".format(repr(k), repr(v))
-            for k, v in iteritems(self))
+            for k, v in self.items())
         return "{{{0}}}".format(", ".join(items))
 
 
@@ -507,8 +493,9 @@ class ListConverter(object):
     def can_convert(self, object):
         # Check for iterator protocol and should not be an instance of byte
         # array (taken care of by protocol)
-        return hasattr2(object, "__iter__") and not isbytearray(object) and\
-            not ispython3bytestr(object) and not isinstance(object, basestring)
+        return hasattr2(object, "__iter__") and \
+            not isinstance(object, bytearray) and \
+            not isinstance(object, bytes) and not isinstance(object, str)
 
     def convert(self, object, gateway_client):
         ArrayList = JavaClass("java.util.ArrayList", gateway_client)

--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -10,12 +10,12 @@ Created on Dec 3, 2009
 
 :author: Barthelemy Dagenais
 """
-from __future__ import unicode_literals, absolute_import
-
 from collections import deque
+import inspect
 import logging
 import os
 from pydoc import pager
+from queue import Queue
 import select
 import socket
 import struct
@@ -26,15 +26,14 @@ import traceback
 from threading import Thread, RLock
 import weakref
 
-from py4j.compat import (
-    range, hasattr2, basestring, CompatThread, Queue)
+from py4j.compat import hasattr2
 from py4j.finalizer import ThreadSafeFinalizer
 from py4j import protocol as proto
 from py4j.protocol import (
     Py4JError, Py4JJavaError, Py4JNetworkError,
     Py4JAuthenticationError,
     get_command_part, get_return_value,
-    register_output_converter, smart_decode, escape_new_line,
+    register_output_converter, escape_new_line,
     is_fatal_error, is_error, unescape_new_line,
     get_error_message, compute_exception_message)
 from py4j.signals import Signal
@@ -451,7 +450,7 @@ def is_instance_of(gateway, java_object, java_class):
     :param java_class: can be a string (fully qualified name), a JavaClass
             instance, or a JavaObject instance)
     """
-    if isinstance(java_class, basestring):
+    if isinstance(java_class, str):
         param = java_class
     elif isinstance(java_class, JavaClass):
         param = java_class._fqn
@@ -613,7 +612,7 @@ def do_client_auth(command, input_stream, sock, auth_token):
             raise Py4JAuthenticationError("Expected {}, received {}.".format(
                 proto.AUTH_COMMAND_NAME, command))
 
-        client_token = smart_decode(input_stream.readline()[:-1])
+        client_token = input_stream.readline()[:-1].decode("utf-8")
         # Remove the END marker
         input_stream.readline()
         if auth_token == client_token:
@@ -644,8 +643,8 @@ def _garbage_collect_object(gateway_client, target_id):
     try:
         try:
             ThreadSafeFinalizer.remove_finalizer(
-                smart_decode(gateway_client.address) +
-                smart_decode(gateway_client.port) +
+                str(gateway_client.address) +
+                str(gateway_client.port) +
                 target_id)
             gateway_client.garbage_collect_object(target_id)
         except Exception:
@@ -694,7 +693,7 @@ def _garbage_collect_proxy(pool, proxy_id):
     return success
 
 
-class OutputConsumer(CompatThread):
+class OutputConsumer(Thread):
     """Thread that consumes output
     """
 
@@ -722,10 +721,10 @@ class OutputConsumer(CompatThread):
     def run(self):
         lines_iterator = iter(self.stream.readline, b"")
         for line in lines_iterator:
-            self.redirect_func(smart_decode(line))
+            self.redirect_func(line.decode("utf-8"))
 
 
-class ProcessConsumer(CompatThread):
+class ProcessConsumer(Thread):
     """Thread that ensures process stdout and stderr are properly closed.
     """
 
@@ -1252,7 +1251,7 @@ class GatewayConnection(object):
                 "Error while sending", e, proto.ERROR_ON_SEND)
 
         try:
-            answer = smart_decode(self.stream.readline()[:-1])
+            answer = self.stream.readline()[:-1].decode("utf-8")
             logger.debug("Answer received: {0}".format(answer))
             if answer.startswith(proto.RETURN_MESSAGE):
                 answer = answer[1:]
@@ -1389,8 +1388,8 @@ class JavaObject(object):
         self._fully_populated = False
         self._gateway_doc = None
 
-        key = smart_decode(self._gateway_client.address) +\
-            smart_decode(self._gateway_client.port) +\
+        key = str(self._gateway_client.address) +\
+            str(self._gateway_client.port) +\
             self._target_id
 
         if self._gateway_client.gateway_property.enable_memory_management:
@@ -2314,7 +2313,7 @@ class CallbackServer(object):
             self.server_socket.listen(5)
             logger.info(
                 "Socket listening on {0}".
-                format(smart_decode(self.server_socket.getsockname())))
+                format(str(self.server_socket.getsockname())))
             server_started.send(
                 self, server=self)
 
@@ -2436,7 +2435,7 @@ class CallbackConnection(Thread):
         authenticated = self.callback_server_parameters.auth_token is None
         try:
             while True:
-                command = smart_decode(self.input.readline())[:-1]
+                command = self.input.readline()[:-1].decode("utf-8")
                 if not authenticated:
                     token = self.callback_server_parameters.auth_token
                     # Will raise an exception if auth fails in any way.
@@ -2444,7 +2443,7 @@ class CallbackConnection(Thread):
                         command, self.input, self.socket, token)
                     continue
 
-                obj_id = smart_decode(self.input.readline())[:-1]
+                obj_id = self.input.readline()[:-1].decode("utf-8")
                 logger.info(
                     "Received command {0} on object id {1}".
                     format(command, obj_id))
@@ -2501,7 +2500,7 @@ class CallbackConnection(Thread):
                 get_command_part('Object ID unknown', self.pool)
 
         try:
-            method = smart_decode(input.readline())[:-1]
+            method = input.readline()[:-1].decode("utf-8")
             params = self._get_params(input)
             return_value = getattr(self.pool[obj_id], method)(*params)
             return proto.RETURN_MESSAGE + proto.SUCCESS +\
@@ -2520,11 +2519,11 @@ class CallbackConnection(Thread):
 
     def _get_params(self, input):
         params = []
-        temp = smart_decode(input.readline())[:-1]
+        temp = input.readline()[:-1].decode("utf-8")
         while temp != proto.END:
             param = get_return_value("y" + temp, self.gateway_client)
             params.append(param)
-            temp = smart_decode(input.readline())[:-1]
+            temp = input.readline()[:-1].decode("utf-8")
         return params
 
 
@@ -2557,7 +2556,7 @@ class PythonProxyPool(object):
             if force_id:
                 id = force_id
             else:
-                id = proto.PYTHON_PROXY_PREFIX + smart_decode(self.next_id)
+                id = proto.PYTHON_PROXY_PREFIX + str(self.next_id)
                 self.next_id += 1
             self.dict[id] = object
         return id

--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -11,7 +11,6 @@ Created on Dec 3, 2009
 :author: Barthelemy Dagenais
 """
 from collections import deque
-import inspect
 import logging
 import os
 from pydoc import pager
@@ -338,7 +337,7 @@ def launch_gateway(port=0, jarpath="", classpath="", javaopts=[],
     # Read the auth token from the server if enabled.
     _auth_token = None
     if enable_auth:
-        _auth_token = proc.stdout.readline()[:-len(os.linesep)]
+        _auth_token = proc.stdout.readline()[:-len(os.linesep)].decode("utf-8")
 
     # Start consumer threads so process does not deadlock/hangs
     OutputConsumer(

--- a/py4j-python/src/py4j/protocol.py
+++ b/py4j-python/src/py4j/protocol.py
@@ -16,16 +16,9 @@ Created on Oct 14, 2010
 
 :author: Barthelemy Dagenais
 """
-from __future__ import unicode_literals, absolute_import
-
 from base64 import standard_b64encode, standard_b64decode
 
 from decimal import Decimal
-
-from py4j.compat import (
-    long, basestring, unicode, bytearray2,
-    bytestr, isbytestr, isbytearray, ispython3bytestr,
-    bytetoint, bytetostr, strtobyte)
 
 
 JAVA_MAX_INT = 2147483647
@@ -159,7 +152,7 @@ DIR_JVMVIEW_SUBCOMMAND_NAME = "v\n"
 OUTPUT_CONVERTER = {
     NULL_TYPE: (lambda x, y: None),
     BOOLEAN_TYPE: (lambda value, y: value.lower() == "true"),
-    LONG_TYPE: (lambda value, y: long(value)),
+    LONG_TYPE: (lambda value, y: int(value)),
     DECIMAL_TYPE: (lambda value, y: Decimal(value)),
     INTEGER_TYPE: (lambda value, y: int(value)),
     BYTES_TYPE: (lambda value, y: decode_bytearray(value)),
@@ -185,7 +178,7 @@ def escape_new_line(original):
     :rtype: an escaped string
     """
     if original:
-        return smart_decode(original).replace("\\", "\\\\").\
+        return original.replace("\\", "\\\\").\
             replace("\r", "\\r").replace("\n", "\\n")
     else:
         return original
@@ -213,17 +206,16 @@ def unescape_new_line(escaped):
 
 
 def smart_decode(s):
-    if isinstance(s, unicode):
+    if isinstance(s, str):
         return s
-    elif isinstance(s, bytestr):
-        # Should never reach this case in Python 3
-        return unicode(s, "utf-8")
+    elif isinstance(s, bytes):
+        return s.decode("utf-8")
     else:
-        return unicode(s)
+        return str(s)
 
 
 def encode_float(float_value):
-    float_str = smart_decode(repr(float_value))
+    float_str = str(float_value)
     if float_str == "-inf":
         float_str = JAVA_NEGATIVE_INFINITY
     elif float_str == "inf":
@@ -234,16 +226,14 @@ def encode_float(float_value):
 
 
 def encode_bytearray(barray):
-    if isbytestr(barray):
-        return bytetostr(standard_b64encode(barray))
+    if isinstance(barray, bytes):
+        return standard_b64encode(barray).decode("ascii")
     else:
-        newbytestr = bytestr(barray)
-        return bytetostr(standard_b64encode(newbytestr))
+        return standard_b64encode(bytes(barray)).decode("ascii")
 
 
 def decode_bytearray(encoded):
-    new_bytes = strtobyte(encoded)
-    return bytearray2([bytetoint(b) for b in standard_b64decode(new_bytes)])
+    return bytearray(standard_b64decode(encoded.encode("ascii")))
 
 
 def is_python_proxy(parameter):
@@ -275,21 +265,21 @@ def get_command_part(parameter, python_proxy_pool=None):
     if parameter is None:
         command_part = NULL_TYPE
     elif isinstance(parameter, bool):
-        command_part = BOOLEAN_TYPE + smart_decode(parameter)
+        command_part = BOOLEAN_TYPE + str(parameter)
     elif isinstance(parameter, Decimal):
-        command_part = DECIMAL_TYPE + smart_decode(parameter)
+        command_part = DECIMAL_TYPE + str(parameter)
     elif isinstance(parameter, int) and parameter <= JAVA_MAX_INT\
             and parameter >= JAVA_MIN_INT:
-        command_part = INTEGER_TYPE + smart_decode(parameter)
-    elif isinstance(parameter, long) or isinstance(parameter, int):
-        command_part = LONG_TYPE + smart_decode(parameter)
+        command_part = INTEGER_TYPE + str(parameter)
+    elif isinstance(parameter, int):
+        command_part = LONG_TYPE + str(parameter)
     elif isinstance(parameter, float):
         command_part = DOUBLE_TYPE + encode_float(parameter)
-    elif isbytearray(parameter):
+    elif isinstance(parameter, bytearray):
         command_part = BYTES_TYPE + encode_bytearray(parameter)
-    elif ispython3bytestr(parameter):
+    elif isinstance(parameter, bytes):
         command_part = BYTES_TYPE + encode_bytearray(parameter)
-    elif isinstance(parameter, basestring):
+    elif isinstance(parameter, str):
         command_part = STRING_TYPE + escape_new_line(parameter)
     elif is_python_proxy(parameter):
         command_part = PYTHON_PROXY_TYPE + python_proxy_pool.put(parameter)

--- a/py4j-python/src/py4j/protocol.py
+++ b/py4j-python/src/py4j/protocol.py
@@ -233,7 +233,7 @@ def encode_bytearray(barray):
 
 
 def decode_bytearray(encoded):
-    return bytearray(standard_b64decode(encoded.encode("ascii")))
+    return bytearray(standard_b64decode(encoded))
 
 
 def is_python_proxy(parameter):

--- a/py4j-python/src/py4j/signals.py
+++ b/py4j-python/src/py4j/signals.py
@@ -7,8 +7,6 @@ The signals pattern is very similar to the listener/observer pattern.
 from inspect import ismethod
 from threading import Lock
 
-from py4j.compat import range
-
 
 def make_id(func):
     if ismethod(func):


### PR DESCRIPTION
Thanks for this project! I have a few perf changes that I think might be valuable to contribute back, so here is one!

Remove Python 2 compatibility layer since Python 2 is no longer supported. This simplifies the codebase, but more importantly **improves performance by eliminating unnecessary type checks and function call overhead**.

Since this project only supports py3.8 and above (https://github.com/py4j/py4j/blob/master/setup.py#L57), this is not a breaking change.


Changes:
- Mostly remove compat module usage from all main source files
- Replace smart_decode() with direct str() or .decode("utf-8") calls
- Use Python 3 built-ins directly (str, bytes, int, range, Queue, Thread)

Benchmark results (isolated microbenchmarks):
- str() vs smart_decode() for integers: 1.90x faster
- str() vs smart_decode() for booleans: 2.61x faster
- str() vs smart_decode() for Decimal: 1.75x faster
- .decode("utf-8") vs smart_decode() for stream reading: 2.01x faster
(micro-benchmarks available here https://gist.github.com/markjm/57cd1731abc0c1ce9820c413b90f992c)

These speedups are probably not game-changing, but given they are there for (now that py2 is totally dead) no reason at all, i figure we may as well take a free win however small.

The compat module is kept for backwards compatibility with any external code that may import from it, but is no longer used internally.