### PR TITLE
Harden test process spawning and teardown to prevent orphan-JVM cascades

### DIFF
--- a/py4j-python/src/py4j/tests/client_server_test.py
+++ b/py4j-python/src/py4j/tests/client_server_test.py
@@ -13,7 +13,8 @@ from py4j.java_gateway import GatewayConnectionGuard, is_instance_of, \
 from py4j.protocol import Py4JError, Py4JJavaError, smart_decode
 from py4j.tests.java_callback_test import IHelloImpl, IHelloFailingImpl
 from py4j.tests.java_gateway_test import (
-    PY4J_JAVA_PATH, check_connection, sleep, WaitOperator)
+    PY4J_JAVA_PATH, check_connection, safe_join, sleep,
+    safe_terminate_process, verify_jvm_or_terminate, WaitOperator)
 from py4j.tests.memory_leak_test import python_gc
 from py4j.tests.py4j_callback_recursive_example import (
     PythonPing, HelloState)
@@ -53,7 +54,6 @@ def start_clientserver_example_app_process(
         args = ("--auth-token", auth_token)
         gw_params = GatewayParameters(auth_token=auth_token)
 
-    # XXX DO NOT FORGET TO KILL THE PROCESS IF THE TEST DOES NOT SUCCEED
     if start_short_timeout:
         p = Process(target=start_short_timeout_clientserver_example_server,
                     args=args)
@@ -67,7 +67,13 @@ def start_clientserver_example_app_process(
     p.start()
     sleep()
 
-    check_connection(gateway_parameters=gw_params)
+    # Verify the JVM actually accepted connections; if not, terminate
+    # the orphan process so it doesn't hold DEFAULT_PORT for the next
+    # test in the same CI cell. Previously this called check_connection
+    # (which silently retries and returns), so a dead JVM looked alive
+    # and downstream tests cascaded with cryptic port-conflict failures
+    # until the 20-minute job timeout fired.
+    verify_jvm_or_terminate(p, gateway_parameters=gw_params)
     return p
 
 
@@ -81,7 +87,10 @@ def clientserver_example_app_process(
         yield p
     finally:
         if join:
-            p.join()
+            # Bounded join + terminate fallback. Replaces unbounded
+            # p.join() which could hang for the full 20-minute CI
+            # timeout if the JVM didn't shut down cleanly.
+            safe_join(p)
 
 
 def start_java_multi_client_server_app():
@@ -91,15 +100,19 @@ def start_java_multi_client_server_app():
 
 
 def start_java_multi_client_server_app_process():
-    # XXX DO NOT FORGET TO KILL THE PROCESS IF THE TEST DOES NOT SUCCEED
     p = Process(target=start_java_multi_client_server_app)
     p.start()
     sleep()
-    # test both gateways...
-    check_connection(
-        gateway_parameters=GatewayParameters(port=DEFAULT_PORT))
-    check_connection(
-        gateway_parameters=GatewayParameters(port=DEFAULT_PORT + 2))
+    # Verify both gateways are up; terminate-and-raise if not (see
+    # rationale in start_clientserver_example_app_process above).
+    try:
+        verify_jvm_or_terminate(
+            p, gateway_parameters=GatewayParameters(port=DEFAULT_PORT))
+        verify_jvm_or_terminate(
+            p, gateway_parameters=GatewayParameters(port=DEFAULT_PORT + 2))
+    except Exception:
+        safe_terminate_process(p)
+        raise
     return p
 
 
@@ -109,7 +122,7 @@ def java_multi_client_server_app_process():
     try:
         yield p
     finally:
-        p.join()
+        safe_join(p)
 
 
 class HelloObjects(object):

--- a/py4j-python/src/py4j/tests/java_callback_test.py
+++ b/py4j-python/src/py4j/tests/java_callback_test.py
@@ -18,7 +18,8 @@ from py4j.java_gateway import (
     set_default_callback_accept_timeout, is_instance_of)
 from py4j.protocol import Py4JJavaError
 from py4j.tests.java_gateway_test import (
-    PY4J_JAVA_PATH, safe_shutdown, sleep, check_connection)
+    PY4J_JAVA_PATH, safe_join, safe_shutdown, sleep, check_connection,
+    verify_jvm_or_terminate)
 
 
 set_default_callback_accept_timeout(0.125)
@@ -56,7 +57,6 @@ def start_example_server3():
 
 
 def start_example_app_process(app=None, args=()):
-    # XXX DO NOT FORGET TO KILL THE PROCESS IF THE TEST DOES NOT SUCCEED
     if not app:
         target = start_example_server
     elif app == "nomem":
@@ -66,7 +66,9 @@ def start_example_app_process(app=None, args=()):
     p = Process(target=target, args=args)
     p.start()
     sleep()
-    check_connection()
+    # Verify the JVM accepted connections; terminate orphan if not.
+    # See verify_jvm_or_terminate docstring for full rationale.
+    verify_jvm_or_terminate(p)
     return p
 
 
@@ -76,24 +78,24 @@ def gateway_example_app_process(app=None, args=()):
     try:
         yield p
     finally:
-        p.join()
+        # Bounded join + terminate fallback (vs unbounded p.join()
+        # which could hang the entire CI cell).
+        safe_join(p)
 
 
 def start_example_app_process2():
-    # XXX DO NOT FORGET TO KILL THE PROCESS IF THE TEST DOES NOT SUCCEED
     p = Process(target=start_example_server2)
     p.start()
     sleep()
-    check_connection()
+    verify_jvm_or_terminate(p)
     return p
 
 
 def start_example_app_process3():
-    # XXX DO NOT FORGET TO KILL THE PROCESS IF THE TEST DOES NOT SUCCEED
     p = Process(target=start_example_server3)
     p.start()
     sleep()
-    check_connection()
+    verify_jvm_or_terminate(p)
     return p
 
 

--- a/py4j-python/src/py4j/tests/java_gateway_test.py
+++ b/py4j-python/src/py4j/tests/java_gateway_test.py
@@ -85,10 +85,11 @@ def start_echo_server():
 
 
 def start_echo_server_process():
-    # XXX DO NOT FORGET TO KILL THE PROCESS IF THE TEST DOES NOT SUCCEED
     sleep()
     p = Process(target=start_echo_server)
     p.start()
+    # Echo server doesn't speak the gateway protocol so we can't probe
+    # it via verify_jvm_or_terminate; rely on the historical 1.5 s wait.
     sleep(1.5)
     return p
 
@@ -112,20 +113,23 @@ def start_ipv6_example_server():
 
 
 def start_example_app_process():
-    # XXX DO NOT FORGET TO KILL THE PROCESS IF THE TEST DOES NOT SUCCEED
     p = Process(target=start_example_server)
     p.start()
     sleep()
-    check_connection()
+    # Verify the JVM actually accepted connections; if not, terminate
+    # the orphan process so it doesn't hold the default port for the
+    # next test. Previously we called check_connection() (which
+    # silently retries and returns) so a dead JVM looked alive and
+    # downstream tests failed with cryptic port conflicts.
+    verify_jvm_or_terminate(p)
     return p
 
 
 def start_short_timeout_app_process():
-    # XXX DO NOT FORGET TO KILL THE PROCESS IF THE TEST DOES NOT SUCCEED
     p = Process(target=start_short_timeout_example_server)
     p.start()
     sleep()
-    check_connection()
+    verify_jvm_or_terminate(p)
     return p
 
 
@@ -166,6 +170,83 @@ def safe_shutdown(instance):
             print_exc()
 
 
+def safe_terminate_process(p, timeout=5):
+    """Best-effort process kill: terminate, then kill if it doesn't exit.
+
+    Used by start-and-verify helpers when the spawned JVM never came up
+    (so we don't leak an orphan process holding the default port for
+    later tests in the same CI cell).
+    """
+    if p is None:
+        return
+    try:
+        if p.is_alive():
+            p.terminate()
+            p.join(timeout=timeout)
+        if p.is_alive():
+            try:
+                p.kill()
+                p.join(timeout=2)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+def safe_join(p, timeout=10):
+    """Bounded process join with terminate fallback.
+
+    Replaces unbounded p.join() in test context managers. The previous
+    pattern would hang the entire CI cell for the full 20-minute job
+    timeout if a JVM didn't shut down cleanly, which then cascaded into
+    port-conflict failures on every subsequent test in the file.
+    """
+    if p is None:
+        return
+    try:
+        p.join(timeout=timeout)
+    except Exception:
+        pass
+    if p.is_alive():
+        safe_terminate_process(p)
+
+
+def verify_jvm_or_terminate(p, gateway_parameters=None):
+    """Verify the spawned JVM is actually accepting connections; if it
+    isn't, terminate the spawned process and raise.
+
+    The lower-level ``check_connection`` swallows ``Py4JNetworkError``
+    (sleeps 2 s and returns) so it can absorb transient races. That's
+    fine when the JVM eventually does come up; it's harmful when the
+    JVM is genuinely dead, because the start helper then returns a
+    "started" process that nothing can connect to and the test fails
+    with a cryptic Py4JError downstream while leaking the orphan
+    process onto the default port. This wrapper catches that case and
+    cleans up.
+    """
+    test_gateway = JavaGateway(gateway_parameters=gateway_parameters)
+    try:
+        test_gateway.jvm.System.currentTimeMillis()
+    except Py4JNetworkError:
+        # Give the JVM another chance, mirroring check_connection's
+        # retry-after-2-seconds policy.
+        sleep(2)
+        try:
+            test_gateway.jvm.System.currentTimeMillis()
+        except Py4JNetworkError as e:
+            test_gateway.close()
+            safe_terminate_process(p)
+            raise Py4JNetworkError(
+                "JVM subprocess did not accept connections; orphan "
+                "process terminated to free port for subsequent tests"
+            ) from e
+    finally:
+        try:
+            test_gateway.close()
+        except Exception:
+            pass
+
+
 @contextmanager
 def gateway(*args, **kwargs):
     g = JavaGateway(
@@ -186,7 +267,7 @@ def example_app_process():
     try:
         yield p
     finally:
-        p.join()
+        safe_join(p)
 
 
 class TestConnection(object):


### PR DESCRIPTION
## Summary

py4j's test suite exhibited a cascading failure pattern on busy CI runners (most often `ubuntu-latest` with Python 3.13 / Java 21): one early test would fail to spawn its JVM cleanly, leak the orphan Java process holding `DEFAULT_PORT` (25333), and every subsequent test in the file would fail with a cryptic `Py4JError` until the 20-minute job timeout fired. We saw 12+ tests fail this way in a single run on PR #577's CI.

This is a **different class of bug** from the timing-budget flakes addressed in #577 — it's a process-cleanup hygiene problem. The fix is to make spawn helpers actively detect a dead JVM and clean up the orphan, and to bound the join timeouts in test context managers.

## Root cause

Two interacting issues:

1. **Spawn helpers silently returned dead processes.** They called `check_connection()`, which swallows `Py4JNetworkError` (sleeps 2 s and returns). So a JVM that never came up looked started: the `Process` handle was returned, the spawning test failed fast on its first call, and the orphan Java subprocess kept holding the port.

2. **Context-manager `finally` blocks used unbounded `p.join()`.** If the JVM didn't shut down cleanly the entire CI cell hung for the full 20-minute job timeout instead of moving on.

## Fix

Three new utilities in `java_gateway_test.py`, imported by the other two test files:

- `safe_terminate_process(p, timeout=5)` — terminate then kill, used by spawn helpers when verification fails
- `safe_join(p, timeout=10)` — bounded join with terminate fallback, replaces unbounded `p.join()`
- `verify_jvm_or_terminate(p, gateway_parameters=None)` — probe with a real method call; terminate orphan and raise `Py4JNetworkError` if the JVM doesn't respond after one retry

Spawn helpers updated to call `verify_jvm_or_terminate(p, ...)` instead of `check_connection(...)`:

- `start_example_app_process` (java_gateway_test.py)
- `start_short_timeout_app_process` (java_gateway_test.py)
- `start_clientserver_example_app_process` (client_server_test.py)
- `start_java_multi_client_server_app_process` (client_server_test.py)
- `start_example_app_process` / `start_example_app_process2` / `start_example_app_process3` (java_callback_test.py)

Context managers updated to use `safe_join(p)` instead of `p.join()`:

- `example_app_process` (java_gateway_test.py)
- `clientserver_example_app_process` (client_server_test.py)
- `java_multi_client_server_app_process` (client_server_test.py)
- `gateway_example_app_process` (java_callback_test.py)

## What's deliberately not changed

- `start_echo_server_process` — the echo server doesn't speak the py4j gateway protocol, so `verify_jvm_or_terminate` can't probe it. Kept the historical 1.5 s wait.
- `start_ipv6_app_process` — being changed in #577 / py4j/py4j to use an IPv6-aware `check_connection` probe; leaving this one for that PR to avoid a merge conflict. Once both PRs are merged, the IPv6 helper can be migrated to `verify_jvm_or_terminate(p, GatewayParameters(address="::1"))` for full consistency.

## Effect

A test that fails its JVM bring-up now fails *itself* (with a clear `"JVM subprocess did not accept connections"` message) and cleans up its orphan process. Subsequent tests in the same file are unaffected. Job-level 20-minute hangs from unclean shutdown are gone.

## Test plan

- [x] All three modified files parse and import cleanly
- [x] Inline comments record the rationale (what was wrong, why each new utility exists, what failure mode it addresses)
- [x] Helpers that can't be probed by the gateway protocol (echo server) are left alone with explanatory comments

This pull request and its description were written by Isaac.