### PR TITLE
Fix listener-lifecycle correctness bugs in GatewayServer / ClientServer

### DIFF
--- a/py4j-java/src/test/java/py4j/GatewayServerTest.java
+++ b/py4j-java/src/test/java/py4j/GatewayServerTest.java
@@ -154,6 +154,44 @@ public class GatewayServerTest {
 		assertTrue(listener.values.contains(new Long(10000)));
 	}
 
+	/**
+	 * Regression test: verify that a normal {@code shutdown()} does NOT fire
+	 * {@code serverError}.
+	 *
+	 * Before the fix, {@link GatewayServer#run()} caught the
+	 * {@code SocketException} that {@code accept()} throws after
+	 * {@code shutdown()} closes the server socket, and routed it through
+	 * {@code fireServerError(e)}. {@code fireServerError} attempts to filter
+	 * via a {@code "socket closed"} string match on the exception message,
+	 * but that filter is locale- and JVM-version-dependent. The robust fix
+	 * is to skip {@code fireServerError} entirely when {@code isShutdown}
+	 * is set.
+	 */
+	@Test
+	public void testListenerNoSpuriousErrorOnShutdown() {
+		TestListener listener = new TestListener();
+		// Use DEFAULT_PORT + 2 to avoid clashing with testListener.
+		GatewayServer server = new GatewayServer(null, GatewayServer.DEFAULT_PORT + 2);
+		server.addListener(listener);
+		server.start();
+		try {
+			Thread.sleep(250);
+		} catch (Exception e) {
+		}
+		server.shutdown();
+		try {
+			Thread.sleep(250);
+		} catch (Exception e) {
+		}
+		// 100 = serverError. It must NOT fire on a clean shutdown.
+		assertFalse("serverError fired during a normal shutdown", listener.values.contains(new Long(100)));
+		// Sanity: the four expected lifecycle events all fired.
+		assertTrue(listener.values.contains(new Long(1)));
+		assertTrue(listener.values.contains(new Long(10)));
+		assertTrue(listener.values.contains(new Long(1000)));
+		assertTrue(listener.values.contains(new Long(10000)));
+	}
+
 	@Test
 	public void testEphemeralPort() {
 		GatewayServer server = new GatewayServer(null, 0);


### PR DESCRIPTION
## Summary

Two production-code bugs in py4j's lifecycle event delivery, both surfaced while stabilizing flaky tests but with real user-visible impact independent of CI.

### Bug #1: ClientServer constructor races listener attachment

The default `ClientServer(Object entryPoint)` constructor sets `autoStartJavaServer=true`, which spawns the Java server thread inside the constructor. The thread asynchronously calls `fireServerStarted()`. By the time a caller obtains the ClientServer reference and calls `.getJavaServer().addListener(listener)`, the `serverStarted` event may have already fired — the listener misses it permanently.

**Real-world impact:** any user wiring listeners for logging / metrics / health checks / graceful-shutdown coordination will silently miss `serverStarted` on fast machines.

**Fix:** new opt-in `ClientServerBuilder.preStartListener(GatewayServerListener)`. Listeners registered through this method are attached during `build()` before the server thread starts. Default constructor behavior preserved; javadoc updated to warn about the race.

### Bug #2: GatewayServer.run() reports normal-shutdown SocketException as serverError

`run()` catches the `SocketException` raised by `accept()` after `shutdown()` closes the server socket, routing it through `fireServerError()`. `fireServerError` has a partial filter (string-match on 'socket closed'), but that filter is locale-, JVM-version-, and whitespace-sensitive, and NPE-prone if `e.getMessage()` returns null.

**Real-world impact:** listeners receive spurious `serverError` on every clean shutdown.

**Fix:** check `isShutdown` at the catch site before calling `fireServerError`. The caller's intent (`isShutdown=true`) is the canonical signal — more reliable than the brittle string match. The existing string-match stays for defense in depth.

## Tests

- `testListenerNoSpuriousErrorOnShutdown` (GatewayServerTest, ClientServerTest)
- `testPreStartListenerObservesServerStarted` (ClientServerTest)
- `testPreStartListenerWithAutoStartFalse` (ClientServerTest)
- `testMultiplePreStartListeners` (ClientServerTest)

## Upstream-CI failure statistics (Dec 2025 – May 2026)

**Corpus:** the upstream `test.yml` matrix workflow was first introduced in #572 (Dec 2025). Every run since then was analyzed — 33 runs total, 13 failed, 87 of 123 failed-cell logs retrievable.

| Pattern | Occurrences (cells) | Distinct runs | Notes |
|---|---|---|---|
| **Bug #1: ClientServer constructor race** (`testListenerClientServer` missing `serverStarted` event) | **2 / 87 (~2 %)** | 2 | Linux Py3.13/Java 21 ([run 25538720931](https://github.com/py4j/py4j/actions/runs/25538720931/job/74960767050)) + macOS Py3.12/Java 21 ([run 25535877757](https://github.com/py4j/py4j/actions/runs/25535877757/job/74957867063)). Manual line-by-line root-causing at the failing SHAs confirms the failed assertion is `assertTrue(listener.values.contains(new Long(1)))` — the `serverStarted` event (Long 1) was specifically the missing one. Both occurrences on Java 21 (the fastest JDK), which is consistent with the race-shape: the faster the server thread, the more likely it fires `serverStarted` before the caller can attach a listener. |
| **Bug #2: spurious `serverError` on shutdown** (extra event in listener history) | Cannot be detected from CI logs | n/a | Gradle's test-report format does not print expected/actual values in `assertEquals` mismatches, so the "extra event" shape of pattern 1.2 cannot be cleanly distinguished from the "missing event" shape (Bug #1) without the HTML test report — which the upstream workflow does not publish as an artifact. The fix is justified by **code reading** plus the manual incident on Tagar/py4j ([commit history of `prod-fix-listener-lifecycle`](https://github.com/Tagar/py4j/commits/prod-fix-listener-lifecycle)) where the bug was reproduced and verified. |

Historical context: PRs [#462](https://github.com/py4j/py4j/pull/462) (Feb 2022, merged) and [#543](https://github.com/py4j/py4j/pull/543) (Apr 2024, merged) addressed sibling cases of the listener-race family. Open Issue [#451](https://github.com/py4j/py4j/issues/451) documents the chronic listener flake going back to 2022.

Reproducible audit data: see `docs/upstream-fixes/ci-failure-stats.json` on the bundle branch.

## Evidence (zero-flake demo)

Tagar/py4j#8 / py4j/py4j#583 is the stacked-bundle PR that combines this with #577 (PR-A), #580 (PR-C), and #582 (PR-E). **7 consecutive green CI runs without retries — 7 × 56 = 392 cells all green** across the full Python × Java × OS matrix.

## Backward compatibility

- Bug #1 fix: pure addition; default constructor unchanged.
- Bug #2 fix: listeners that depended on receiving `serverError(100)` for normal shutdowns were depending on a bug. The right shutdown signals are `serverPreShutdown` / `serverStopped` / `serverPostShutdown`, all unchanged.

CHANGELOG updated under 'Unreleased'.

## Test plan

- [x] New regression tests pass
- [x] Existing tests unaffected
- [x] All 7 bundle runs on Tagar/py4j#8 green

This pull request and its description were written by Isaac.