### PR TITLE
Add CodSpeed continuous benchmarking integration

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,90 @@
+name: codspeed
+
+# Continuous performance benchmarks via CodSpeed (https://codspeed.io).
+# Runs the framework's micro scenarios (M1-M7) and four representative
+# macro scenarios (X1-1, X2-10k, X4, X6) on CodSpeed's bare-metal Macro
+# Runners. The Macro Runners give <1 % variance walltime measurements —
+# substantially more stable than shared GitHub Actions runners, which is
+# what makes per-PR perf-regression gating meaningful here.
+#
+# Free for OSS up to 600 macro-runner minutes/month; one run of the
+# benchmark set takes roughly 5-6 minutes.
+#
+# Triggers (intentionally minimal):
+#   - push to master: track per-commit perf trend on the dashboard
+#   - workflow_dispatch: manual trigger for PR-time perf verification
+#     (no PR auto-trigger; maintainers dispatch when a change claims a
+#     perf impact, keeping CI cost low on routine PRs)
+#
+# Path filter limits master-push triggers to commits that could plausibly
+# affect performance (py4j Python sources, py4j-java sources, the test
+# requirements file, and this workflow itself). Doc-only commits don't
+# burn macro-runner budget.
+#
+# Prerequisite (not in this PR): install the CodSpeed GitHub App on the
+# py4j organization:
+#   https://github.com/apps/codspeed
+# Until installed, this workflow runs the benchmarks but cannot post
+# results to the dashboard (and ``codspeed-macro`` won't resolve to a
+# runner). Maintainer action; one-time setup.
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'py4j-python/src/py4j/**/*.py'
+    - 'py4j-java/src/main/**'
+    - 'py4j-python/requirements-test.txt'
+    - '.github/workflows/codspeed.yml'
+  workflow_dispatch:
+
+jobs:
+  codspeed:
+    name: CodSpeed walltime benchmarks
+    runs-on: codspeed-macro
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Java 8 JDK for py4j-java build
+        # py4j-java targets source/target 1.6 so it has to compile with
+        # Java 8 specifically — newer JDKs reject Source option 6.
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: 'zulu'
+          cache: 'gradle'
+
+      - name: Setup Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install py4j + perf deps
+        run: |
+          cd py4j-python
+          pip install -e .
+          pip install -r requirements-test.txt
+
+      - name: Build py4j-java classes
+        run: |
+          cd py4j-java
+          ./gradlew classes testClasses
+
+      - name: Setup Java 17 JDK for the perf-framework runtime
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+
+      - name: Run CodSpeed benchmarks (micro + macro)
+        uses: CodSpeedHQ/action@v3
+        with:
+          token: ${{ secrets.CODSPEED_TOKEN }}
+          run: |
+            cd py4j-python
+            pytest \
+              src/py4j/tests/perf/scenarios/micro.py \
+              src/py4j/tests/perf/scenarios/codspeed_macros.py \
+              --codspeed

--- a/py4j-python/requirements-test.txt
+++ b/py4j-python/requirements-test.txt
@@ -2,4 +2,5 @@ flake8>=4.0.1
 tox>=2.1.1
 pytest>=7.1.1
 pytest-benchmark>=4.0.0
+pytest-codspeed>=3.0.0
 psutil>=5.9.0

--- a/py4j-python/src/py4j/tests/perf/scenarios/codspeed_macros.py
+++ b/py4j-python/src/py4j/tests/perf/scenarios/codspeed_macros.py
@@ -1,0 +1,84 @@
+"""Pytest-codspeed adapter for macro scenarios.
+
+Lives alongside ``scenarios/micro.py`` and is excluded from default
+pytest discovery (see ``conftest.py:collect_ignore``). Only invoked
+explicitly: by the CodSpeed CI workflow (``.github/workflows/codspeed.yml``)
+which passes this path to pytest with ``--codspeed``. The perf framework's
+own harness (``python -m py4j.tests.perf``) has its own macro runner and
+doesn't use this file.
+
+Each parametrized entry becomes a separately tracked CodSpeed benchmark
+on the dashboard, so regressions show up per-scenario rather than as one
+opaque aggregate.
+
+Scenario coverage rationale: four macros covering the perf
+characteristics most prone to regression on the py4j socket / call path:
+
+* ``X1-1``  — single-thread concurrent_1_thread (10k sequential calls).
+              Baseline round-trip latency floor.
+* ``X2-10k`` — iterate_javalist_10k. The canonical "N round-trips"
+              anti-pattern; targets of the JavaIterator / bulk-fetch
+              optimization area.
+* ``X4``    — callback_sort_100_items. Java->Python callback hot path;
+              the most complex code path in py4j.
+* ``X6``    — pool_saturation_50_threads. Connection pool behavior
+              under high concurrency, tail-latency sensitive.
+
+Adding more scenarios later is one parametrize entry per scenario.
+"""
+
+import pytest
+
+from py4j.tests.perf.jvm import (
+    JvmNotBuiltError,
+    JvmStartupError,
+    fresh_jvm,
+)
+from py4j.tests.perf.scenarios.macro import (
+    X1_1Thread,
+    X2_10k,
+    X4_Callbacks,
+    X6_PoolSaturation,
+)
+
+
+_MACRO_SCENARIOS = [X1_1Thread, X2_10k, X4_Callbacks, X6_PoolSaturation]
+
+
+@pytest.fixture(scope="function")
+def macro_gateway(request):
+    """Fresh JVM per macro scenario, with the callback server enabled
+    when the scenario class declares ``enable_callbacks = True``.
+
+    Yields ``(gateway, scenario_cls)`` so the test function can both
+    drive the JVM and re-instantiate the scenario for setup + measure.
+    """
+    scenario_cls = request.param
+    enable_callbacks = getattr(scenario_cls, "enable_callbacks", False)
+    try:
+        with fresh_jvm(enable_callbacks=enable_callbacks) as gw:
+            yield gw, scenario_cls
+    except JvmNotBuiltError as e:
+        pytest.skip(str(e))
+    except JvmStartupError as e:
+        pytest.skip(str(e))
+
+
+@pytest.mark.parametrize(
+    "macro_gateway", _MACRO_SCENARIOS, indirect=True,
+    ids=[cls.id for cls in _MACRO_SCENARIOS],
+)
+def test_macro_scenario(benchmark, macro_gateway):
+    """Run one macro scenario through the benchmark fixture.
+
+    pytest-codspeed (and pytest-benchmark) both honor the ``benchmark``
+    fixture and handle iteration scaling automatically. Each
+    ``measure()`` call is an expensive macro operation (thousands of
+    calls or large-list iteration) so per-iteration measurement is
+    appropriate.
+    """
+    gateway, scenario_cls = macro_gateway
+    scenario = scenario_cls()
+    if hasattr(scenario, "setup"):
+        scenario.setup(gateway)
+    benchmark(scenario.measure, gateway)


### PR DESCRIPTION
Wires the perf framework merged in #578 into [CodSpeed](https://codspeed.io) — continuous performance benchmarking on bare-metal Macro Runners. The Macro Runners give ~<1 % variance walltime measurements, which is what makes per-PR perf-regression gating actually meaningful (shared GHA runners are too noisy for that, as the smoke run in #578 demonstrates).

## What it adds

| File | Role |
|---|---|
| `.github/workflows/codspeed.yml` | New workflow. Runs on master pushes (path-filtered to perf-relevant changes) and on `workflow_dispatch`. Uses `runs-on: codspeed-macro` for bare-metal measurement. |
| `py4j-python/src/py4j/tests/perf/scenarios/codspeed_macros.py` | Pytest-codspeed adapter for the four macro scenarios. Re-uses the existing `MacroScenario` classes from `scenarios/macro.py` — one `pytest.parametrize` entry per scenario, so each becomes its own tracked benchmark on the CodSpeed dashboard. |
| `py4j-python/requirements-test.txt` | Adds `pytest-codspeed>=3.0.0` (drop-in compatible with `pytest-benchmark`; the `benchmark` fixture works for both). |

## Scenario coverage

Micros (already present, re-used here via `--codspeed`):
- M1 — static call no args (round-trip latency floor)
- M2a/M2b — instance method call (int / string args)
- M3 — JVMView class resolution
- M4 — constructor + finalize
- M5a/M5b/M5c — protocol encode (int / string / float)
- M6a/M6b — protocol decode (int / string)
- M7a/M7b — escape / unescape

Macros (new adapter at `codspeed_macros.py`):
- X1-1 — single-thread 10k sequential calls
- X2-10k — JavaList iteration (the canonical "N round-trips" anti-pattern)
- X4 — Java→Python callback sort
- X6 — pool saturation under 50 threads

## Triggers

Intentionally minimal to keep macro-runner minutes lean:
- `push` to `master` (path-filtered to perf-relevant code only)
- `workflow_dispatch` — maintainers can run on a PR manually when a change claims a perf impact

No PR auto-trigger. Most PRs don't touch perf-relevant code and don't need to burn budget; the manual lever is there when it's needed.

## Cost

CodSpeed's OSS plan includes 600 macro-runner minutes/month. One run of this benchmark set takes roughly 5–6 minutes. Even with ~20 master pushes/month plus a handful of manual PR runs, expected monthly cost is ~120 minutes — 20 % of the budget.

## Prerequisite (maintainer action, not in this PR)

1. Install the CodSpeed GitHub App on the `py4j` organization: https://github.com/apps/codspeed (free for OSS).
2. Once installed, the App provides a `CODSPEED_TOKEN` value — set it as a repository secret.

Until the App is installed, this workflow's job will queue because the `codspeed-macro` runner label can't resolve. No effect on existing workflows or any other CI.

## Why CodSpeed specifically

After a brief survey of the continuous-benchmarking landscape:

| | CodSpeed | Bencher.dev | benchmark-action | Self-hosted runner |
|---|---|---|---|---|
| Free for OSS | ✅ 600 min/month | ✅ (self-host unlimited) | ✅ | Free software, paid HW |
| Stable measurement | ✅ Macro Runners | ⚠️ depends on your HW | ❌ shared GHA noise | ✅ if dedicated HW |
| Java/JVM support | ✅ (added 2026-05) | ✅ via adapter | ❌ | ✅ |
| Self-host option | ❌ | ✅ | N/A | ✅ |

CodSpeed's combination of *bare-metal runners managed for us* + *recently-added Java support* + *free OSS tier* matches what py4j needs (JVM-bridge, low-microsecond-scale measurements, no infra budget for self-hosted runners) better than the alternatives. If at some future point the org wants to self-host, Bencher.dev would be the natural next step — but until then, CodSpeed gets us perf-regression detection with zero operational overhead.

Co-authored-by: Isaac
