### PR TITLE
codspeed.yml: add opt-in perf-check label trigger

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -10,16 +10,17 @@ name: codspeed
 # Free for OSS up to 600 macro-runner minutes/month; one run of the
 # benchmark set takes roughly 5-6 minutes.
 #
-# Triggers (intentionally minimal):
+# Triggers:
 #   - push to master: track per-commit perf trend on the dashboard
-#   - workflow_dispatch: manual trigger for PR-time perf verification
-#     (no PR auto-trigger; maintainers dispatch when a change claims a
-#     perf impact, keeping CI cost low on routine PRs)
+#   - pull_request with the `perf-check` label: opt-in per-PR
+#     CodSpeed comments. Maintainers apply the label on PRs whose perf
+#     impact is uncertain; routine PRs don't burn macro-runner budget.
+#   - workflow_dispatch: manual trigger, available always
 #
-# Path filter limits master-push triggers to commits that could plausibly
-# affect performance (py4j Python sources, py4j-java sources, the test
-# requirements file, and this workflow itself). Doc-only commits don't
-# burn macro-runner budget.
+# Path filter limits triggers to commits that could plausibly affect
+# performance (py4j Python sources, py4j-java sources, the test
+# requirements file, and this workflow itself). Doc-only commits
+# don't burn macro-runner budget.
 #
 # Prerequisite (not in this PR): install the CodSpeed GitHub App on the
 # py4j organization:
@@ -37,11 +38,29 @@ on:
     - 'py4j-java/src/main/**'
     - 'py4j-python/requirements-test.txt'
     - '.github/workflows/codspeed.yml'
+  pull_request:
+    types: [labeled, synchronize]
+    branches:
+    - master
+    paths:
+    - 'py4j-python/src/py4j/**/*.py'
+    - 'py4j-java/src/main/**'
+    - 'py4j-python/requirements-test.txt'
+    - '.github/workflows/codspeed.yml'
   workflow_dispatch:
 
 jobs:
   codspeed:
     name: CodSpeed walltime benchmarks
+    # Opt-in per-PR runs gated on the ``perf-check`` label:
+    #   - ``labeled`` events fire only for the perf-check label
+    #   - ``synchronize`` events (new commits on a PR) only fire if the
+    #     PR already carries the label
+    # ``push`` and ``workflow_dispatch`` always run.
+    if: >
+      github.event_name != 'pull_request' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'perf-check') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'perf-check'))
     runs-on: codspeed-macro
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Adds an opt-in path to fire CodSpeed on a PR by applying the `perf-check` label, so maintainers can request a perf-comparison comment on changes where the impact is uncertain — without flipping CodSpeed on for every PR (which would burn the 600 min/month OSS macro-runner budget on routine no-perf-impact PRs).

Existing triggers (push to master, workflow_dispatch) are unchanged.

## Mechanism

- The `pull_request` trigger subscribes only to `labeled` and `synchronize` events, narrowed by the existing perf-relevant path filter.
- A job-level `if:` ensures the workflow only actually runs benchmarks when:
  - A `labeled` event added the `perf-check` label specifically, OR
  - A `synchronize` event arrives on a PR that already carries the label.
- Unrelated label additions show as a "Skipped" job in the Actions UI but consume no runner time.

## How to use

A maintainer applies the `perf-check` label to a PR. CodSpeed runs and posts its standard perf-delta comment on the PR. Subsequent pushes to the PR branch re-fire the workflow automatically as long as the label is still present.

For PRs with broad perf relevance (e.g. anything touching the protocol hot paths in `protocol.py` or the encoding / decoding logic in `java_gateway.py`), labeling early in review surfaces perf data the same way CI surfaces test results — visible during review, not buried in the dashboard.

## Cost

Conservative: maybe 1-2 PRs/month get labeled, each producing 1-3 codspeed runs (label + a couple of pushes), so ~20-50 macro-runner minutes/month. Trivial against the 600-min budget.

## What this is not

This doesn't change anything about the push-to-master trend tracking on the CodSpeed dashboard — that continues exactly as before. Master-push runs continue to populate the per-commit perf history visible at https://codspeed.io/py4j/py4j/runs.

Co-authored-by: Isaac
