### PR TITLE
Fix invalid perf-framework workflow (paths + paths-ignore conflict)

### DIFF
--- a/.github/workflows/perf-framework.yml
+++ b/.github/workflows/perf-framework.yml
@@ -17,23 +17,24 @@ on:
     branches:
     - master
     paths:
+    # Include perf-framework code, excluding doc-only changes within it
+    # (GitHub Actions rejects `paths` + `paths-ignore` together in the
+    # same trigger; the `!` negation prefix inside a single `paths:` list
+    # is the supported way to combine include + exclude).
     - 'py4j-python/src/py4j/tests/perf/**'
+    - '!py4j-python/src/py4j/tests/perf/**/*.md'
     - 'py4j-python/src/py4j/tests/test_perf_framework.py'
     - 'py4j-python/requirements-test.txt'
     - '.github/workflows/perf-framework.yml'
-    paths-ignore:
-    # Doc-only changes never affect framework behavior; skip the run.
-    - '**/*.md'
   pull_request:
     branches:
     - master
     paths:
     - 'py4j-python/src/py4j/tests/perf/**'
+    - '!py4j-python/src/py4j/tests/perf/**/*.md'
     - 'py4j-python/src/py4j/tests/test_perf_framework.py'
     - 'py4j-python/requirements-test.txt'
     - '.github/workflows/perf-framework.yml'
-    paths-ignore:
-    - '**/*.md'
   # Manual trigger from the Actions UI — useful when you want to
   # re-run perf coverage after merging upstream master or to test the
   # workflow itself.


### PR DESCRIPTION
The `perf-framework.yml` workflow currently fails to parse with:

```
Invalid workflow file
.github/workflows/perf-framework.yml (Line: 24, Col: 5):
you may only define one of `paths` and `paths-ignore`
```

Example failing run: https://github.com/py4j/py4j/actions/runs/26128266206

GitHub Actions rejects having both `paths` and `paths-ignore` under the same trigger block. The workflow had both (include perf-framework code + exclude `**/*.md`) under each of the `push` and `pull_request` triggers, so neither trigger could fire — runs would show conclusion=failure with zero jobs spawned.

## Fix

Replace the separate `paths-ignore` block with a `!`-prefixed negation pattern inside the existing `paths:` list, which is the documented supported way to combine include + exclude in a single filter:

```yaml
paths:
- 'py4j-python/src/py4j/tests/perf/**'
- '!py4j-python/src/py4j/tests/perf/**/*.md'
- 'py4j-python/src/py4j/tests/test_perf_framework.py'
- 'py4j-python/requirements-test.txt'
- '.github/workflows/perf-framework.yml'
```

Same behavior as intended: trigger on perf-framework code changes, skip doc-only (`*.md`) changes within the perf-framework directory.

Workflow-only change; no Python or Java code touched.

Co-authored-by: Isaac