### PR TITLE
build+ci: drop jcenter (sunset 2021) + retry Gradle on transient CDN failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,11 +53,35 @@ jobs:
           ./gradlew clean
         shell: bash
 
-      - name: Run Gradle tests
+      - name: Run Gradle tests (3 attempts on transient CDN failures)
+        # Maven Central / Gradle wrapper downloads occasionally fail on
+        # fresh CI runners with empty caches. Build genuinely-failing
+        # tests will fail the same way on each retry, just slower; the
+        # backoff (20s, 40s) prevents thundering-herd against an
+        # already-troubled CDN. Real test failures still report
+        # cleanly via the last attempt's exit code.
+        #
+        # shell: bash is REQUIRED — on windows-latest the default shell
+        # is PowerShell, which does not understand bash's for/do/done
+        # loop syntax. shell: bash uses Git Bash on Windows runners
+        # (preinstalled) for cross-platform consistency.
+        shell: bash
         run: |
           cd py4j-java
-          ./gradlew check
-          ./gradlew assemble
+          for attempt in 1 2 3; do
+            echo "::group::Gradle attempt $attempt/3"
+            if ./gradlew check && ./gradlew assemble; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ $attempt -lt 3 ]; then
+              backoff=$((attempt * 20))
+              echo "Gradle build failed (attempt $attempt/3); retrying in ${backoff}s"
+              sleep "$backoff"
+            fi
+          done
+          exit 1
 
       - name: Setup Java ${{ matrix.java-version }} JDK for PyTest
         if: ${{ matrix.java-version != '8' }}

--- a/py4j-java/build.gradle
+++ b/py4j-java/build.gradle
@@ -80,7 +80,14 @@ if (JavaVersion.current().isJava8Compatible()) {
 
 buildscript {
     repositories {
-        jcenter()
+        // jcenter() (JFrog Bintray) was sunset in May 2021 and is
+        // increasingly unreliable — fresh CI runners (e.g. windows-
+        // latest with an empty gradle cache) fail dependency
+        // resolution intermittently. Both classpath artifacts below
+        // are mirrored on Maven Central; the gradle plugin portal
+        // is added as a defensive fallback for plugin resolution.
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
         // Only add spotless for JDK >= 1.8


### PR DESCRIPTION
Two small CI/build-resilience fixes that together unblock master from intermittent dependency-resolution failures.

## What's in

### 1. `build.gradle`: drop `jcenter()` in favor of `mavenCentral()` + `gradlePluginPortal()`

JFrog sunset Bintray / JCenter in May 2021. The endpoint still serves cached artifacts on warm runners but increasingly 404s on fresh CI runners with empty Gradle caches. Both buildscript classpath artifacts (`com.diffplug.gradle.spotless:spotless:1.3.2` and `org.standardout:bnd-platform:1.3.0`) are mirrored on Maven Central; `gradlePluginPortal()` is added as a defensive fallback for any future plugin lookups.

### 2. `.github/workflows/test.yml`: 3-attempt retry around `./gradlew check && ./gradlew assemble`

Maven Central can return 403 / 5xx on individual artifact requests (e.g., FindBugs `maven-metadata.xml` recently hit this). The retry loop has 20s/40s backoff between attempts — real test failures still report cleanly via the final attempt's exit code, transient flakes get auto-recovery. `shell: bash` is set explicitly so the loop syntax works on Windows runners (which default to PowerShell).

## Validation

Both changes were incubated and validated in [byteoak/py4j](https://github.com/byteoak/py4j), a fork I maintain that runs a copy of this repo's matrix:

- jcenter → mavenCentral: [byteoak#8](https://github.com/byteoak/py4j/pull/8), 56/56 matrix green
- Gradle retry + `shell: bash`: [byteoak#11](https://github.com/byteoak/py4j/pull/11), 55/56 matrix green (1 stale-in-progress on an already-passing run)

The cherry-picks here are byteoak's squash-merge commits applied to upstream master. No code paths added or modified — workflow + build script only.

Co-authored-by: Isaac