### PR TITLE
perf: ×42 on byte round-trip via TCP_NODELAY (closes #516)

### DIFF
--- a/py4j-java/src/main/java/py4j/CallbackConnection.java
+++ b/py4j-java/src/main/java/py4j/CallbackConnection.java
@@ -225,6 +225,10 @@ public class CallbackConnection implements Py4JClientConnection {
 		logger.info("Starting Communication Channel on " + address + " at " + port);
 		socket = socketFactory.createSocket(address, port);
 		socket.setSoTimeout(blockingReadTimeout);
+		// Disable Nagle's algorithm (see ClientServerConnection for the
+		// rationale; same issue #516 pattern applies on the callback
+		// connection path).
+		socket.setTcpNoDelay(true);
 		reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), Charset.forName("UTF-8")));
 		writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), Charset.forName("UTF-8")));
 

--- a/py4j-java/src/main/java/py4j/ClientServerConnection.java
+++ b/py4j-java/src/main/java/py4j/ClientServerConnection.java
@@ -74,6 +74,15 @@ public class ClientServerConnection implements Py4JServerConnection, Py4JClientC
 					throws IOException {
 		super();
 		this.socket = socket;
+		// Disable Nagle's algorithm to avoid the write-write-read latency
+		// penalty (issue #516): a write that exceeds the BufferedWriter's
+		// buffer is flushed in two parts, Nagle holds the second part
+		// until the delayed-ACK timer fires, and per-call latency jumps
+		// from <1 ms to ~40 ms. Py4J runs over loopback or low-latency
+		// LAN (same-host JVM, cluster), so Nagle's coalescing brings no
+		// benefit, only the bug. Modern RPC systems (gRPC, Thrift) do
+		// this unconditionally for the same reason.
+		socket.setTcpNoDelay(true);
 		this.reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), Charset.forName("UTF-8")));
 		this.writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), Charset.forName("UTF-8")));
 		this.commands = new HashMap<String, Command>();

--- a/py4j-java/src/main/java/py4j/GatewayConnection.java
+++ b/py4j-java/src/main/java/py4j/GatewayConnection.java
@@ -135,6 +135,10 @@ public class GatewayConnection implements Runnable, Py4JServerConnection {
 			List<Class<? extends Command>> customCommands, List<GatewayServerListener> listeners) throws IOException {
 		super();
 		this.socket = socket;
+		// Disable Nagle's algorithm (see ClientServerConnection for the
+		// rationale; same issue #516 pattern applies on the JavaGateway
+		// path).
+		socket.setTcpNoDelay(true);
 		this.authToken = authToken;
 		if (authToken != null) {
 			this.authCommand = new AuthCommand(authToken);

--- a/py4j-python/src/py4j/clientserver.py
+++ b/py4j-python/src/py4j/clientserver.py
@@ -19,7 +19,8 @@ from py4j.java_gateway import (
     CallbackServerParameters, GatewayParameters, CallbackServer,
     GatewayConnectionGuard, DEFAULT_ADDRESS, DEFAULT_PORT,
     DEFAULT_PYTHON_PROXY_PORT, DEFAULT_ACCEPT_TIMEOUT_PLACEHOLDER,
-    server_connection_stopped, do_client_auth, _garbage_collect_proxy)
+    server_connection_stopped, do_client_auth, _garbage_collect_proxy,
+    disable_nagle)
 from py4j import protocol as proto
 from py4j.protocol import (
     Py4JError, Py4JNetworkError, smart_decode, get_command_part,
@@ -432,6 +433,7 @@ class ClientServerConnection(object):
                 self.socket = self.ssl_context.wrap_socket(
                     self.socket, server_hostname=self.java_address)
             self.socket.connect((self.java_address, self.java_port))
+            disable_nagle(self.socket)
             self.stream = self.socket.makefile("rb")
             self.is_connected = True
             self.initiated_from_client = True

--- a/py4j-python/src/py4j/java_gateway.py
+++ b/py4j-python/src/py4j/java_gateway.py
@@ -139,6 +139,34 @@ def set_reuse_address(server_socket):
             socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
 
+def disable_nagle(sock):
+    """Disable Nagle's algorithm (set TCP_NODELAY) on a TCP socket.
+
+    Py4J's text protocol is a classic write-write-read pattern: a single
+    method call frequently triggers two writes (command body + END marker
+    or, for large payloads, a BufferedWriter overflow that flushes in two
+    parts). Nagle's algorithm holds the second write waiting to coalesce,
+    which interacts with delayed ACK and adds ~40 ms per affected call —
+    turning sub-millisecond round-trips into 40 ms+ operations (see
+    issue #516, where 8 KB ByteBuffer.array() round-trips went from
+    expected sub-millisecond to ~44 ms each).
+
+    Py4J runs over loopback or low-latency LAN (PySpark driver↔executor,
+    same-host JVM); the Nagle coalescing benefit doesn't apply to either,
+    while the write-write-read penalty hits the same way on both. Every
+    modern RPC system (gRPC, Thrift, …) disables Nagle by default for
+    exactly this reason.
+
+    Best-effort: setsockopt errors are swallowed because TCP_NODELAY is
+    performance-only, not correctness-critical (e.g. AF_UNIX sockets
+    don't support the option).
+    """
+    try:
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    except OSError:
+        pass
+
+
 def set_default_callback_accept_timeout(accept_timeout):
     """Sets default accept timeout of callback server.
     """
@@ -1165,6 +1193,7 @@ class GatewayConnection(object):
         """
         try:
             self.socket.connect((self.address, self.port))
+            disable_nagle(self.socket)
             self.stream = self.socket.makefile("rb")
             self.is_connected = True
 
@@ -2338,6 +2367,7 @@ class CallbackServer(object):
 
                 for s in readable:
                     socket_instance, _ = self.server_socket.accept()
+                    disable_nagle(socket_instance)
                     if self.callback_server_parameters.read_timeout:
                         socket_instance.settimeout(
                             self.callback_server_parameters.read_timeout)

--- a/py4j-python/src/py4j/tests/nagle_test.py
+++ b/py4j-python/src/py4j/tests/nagle_test.py
@@ -1,0 +1,129 @@
+"""Unit + integration tests for the disable_nagle helper and its
+wiring across the gateway connection paths.
+
+The helper itself is pure-Python (no JVM required). The integration
+tests open real JavaGateway / ClientServer connections and inspect
+the TCP_NODELAY socket option on the live socket — a regression guard
+that future refactors don't drop the setting.
+
+See java_gateway.py:disable_nagle for rationale (issue #516).
+"""
+import socket
+import threading
+import unittest
+from unittest import TestCase
+
+from py4j.java_gateway import disable_nagle
+
+
+def _make_loopback_pair():
+    """Return (client_sock, server_sock) both connected on loopback."""
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+
+    accepted = []
+
+    def _accept():
+        s, _ = listener.accept()
+        accepted.append(s)
+
+    t = threading.Thread(target=_accept)
+    t.start()
+
+    client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    client.connect(("127.0.0.1", port))
+    t.join(timeout=2)
+    listener.close()
+
+    return client, accepted[0]
+
+
+class DisableNagleHelperTest(TestCase):
+    """Unit tests for the helper itself."""
+
+    def test_sets_tcp_nodelay(self):
+        client, server = _make_loopback_pair()
+        try:
+            # Pre-condition: TCP_NODELAY is off by default.
+            before = client.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
+            self.assertFalse(
+                before,
+                "TCP_NODELAY should be off by default (got {!r})".format(
+                    before))
+
+            disable_nagle(client)
+
+            # getsockopt's int interpretation of TCP_NODELAY varies by
+            # platform (Linux returns 1, macOS may return another truthy
+            # int such as 4). Test boolean semantics: "enabled".
+            after = client.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
+            self.assertTrue(
+                after,
+                "TCP_NODELAY should be enabled after disable_nagle "
+                "(got {!r})".format(after))
+        finally:
+            client.close()
+            server.close()
+
+    def test_swallows_setsockopt_error(self):
+        # Helper must not raise if the kernel rejects the option (e.g.
+        # closed socket, AF_UNIX socket). Best-effort by contract.
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.close()
+        disable_nagle(sock)  # must not raise
+
+
+class GatewayConnectionNagleIntegrationTest(unittest.TestCase):
+    """Integration: a real JavaGateway connection has TCP_NODELAY set
+    on the underlying socket. Regression guard that the wiring in
+    GatewayConnection.start() isn't dropped or moved before the connect."""
+
+    def setUp(self):
+        from py4j.tests.java_gateway_test import start_example_app_process
+        self.p = start_example_app_process()
+        from py4j.java_gateway import JavaGateway
+        self.gateway = JavaGateway()
+
+    def tearDown(self):
+        from py4j.tests.java_gateway_test import safe_shutdown, safe_join
+        safe_shutdown(self)
+        safe_join(self.p)
+
+    def test_gateway_connection_has_tcp_nodelay(self):
+        # Force a connection to be opened by making one JVM call.
+        self.gateway.jvm.java.lang.System.currentTimeMillis()
+
+        # Grab a connection from the pool and inspect its socket.
+        client = self.gateway._gateway_client
+        # _give_back_connection won't help us hold a ref; pop one off
+        # the deque directly (we know there's at least one after the
+        # call above).
+        conn = client.deque[0]
+        nodelay = conn.socket.getsockopt(
+            socket.IPPROTO_TCP, socket.TCP_NODELAY)
+        self.assertTrue(
+            nodelay,
+            "GatewayConnection.start() must call disable_nagle() "
+            "after socket.connect() (got {!r})".format(nodelay))
+
+    def test_bytebuffer_array_8k_does_not_take_seconds(self):
+        # Behavioral regression guard: issue #516's reproducer. With
+        # Nagle enabled, ByteBuffer.allocate(8192).array() in a loop
+        # of 100 took ~4.4 s due to the write-write-read interaction
+        # with delayed ACK. With TCP_NODELAY enabled it should be
+        # sub-second by a wide margin. 1.5 s is a generous bound that
+        # holds even on slow CI runners; a Nagle regression would
+        # blow well past it.
+        import time
+        buf = self.gateway.jvm.java.nio.ByteBuffer.allocate(8192)
+        start = time.monotonic()
+        for _ in range(100):
+            buf.array()
+        elapsed = time.monotonic() - start
+        self.assertLess(
+            elapsed, 1.5,
+            "100x ByteBuffer.allocate(8192).array() took {:.2f}s — Nagle "
+            "regression? (issue #516 baseline: ~4.4s with Nagle on, "
+            "<0.05s with TCP_NODELAY on)".format(elapsed))


### PR DESCRIPTION
Disables Nagle's algorithm on every py4j socket connection — both languages, all 3 Java connection classes, all 3 Python connect/accept sites. Closes the long-standing perf issue reported in #516 (and acknowledges @trohwer's earlier loopback-only fix proposal in #517).

## CodSpeed measurement (×42)

Measured on byteoak/py4j's CodSpeed runner — Linux, the X7-16k bytes-roundtrip macro added in #591:

|  | BASE (master) | HEAD (this PR) | Efficiency |
|---|---|---|---|
| ⚡ | `X7-16k` | 4,399.8 ms | 103.6 ms | **×42** |

That's the issue #516 reproducer captured exactly: 100 iterations of `ByteBuffer.allocate(8192).array()` taking 4.4 s with Nagle on, collapsing to ~100 ms with `TCP_NODELAY` enabled.

## Why

py4j's text protocol is a write-write-read pattern: most method calls flush in two parts (command body + END marker, or a BufferedWriter overflow for large payloads). Nagle holds the second write waiting to coalesce; delayed-ACK on the receiver waits for piggyback opportunity; per-call latency jumps from sub-millisecond to ~40 ms.

py4j runs over loopback (same-host JVM) or low-latency LAN (PySpark driver↔executor in a cluster). Nagle's coalescing brings no benefit in either case, only the bug. Every modern RPC system (gRPC, Thrift) disables Nagle unconditionally for the same reason.

@trohwer's #517 proposed disabling on loopback only; this PR broadens to unconditional (the same write-write-read pattern hits on low-latency LAN too) and covers both Python and all 3 Java connection classes.

## Sites covered

**Python (3 socket-creation sites):**
- `GatewayConnection.start()` — JavaGateway client connect
- `CallbackServer` accept loop — Java→Python callback accept
- `ClientServerConnection.connect_to_java_server()` — ClientServer mode client connect (`PythonServer` accept inherits `CallbackServer`'s patched loop)

**Java (3 connection classes):**
- `GatewayConnection` — JavaGateway server-side
- `ClientServerConnection` — ClientServer mode (both directions)
- `CallbackConnection` — Java→Python callback client-side

The Python side uses a small `disable_nagle()` helper added next to the existing `set_reuse_address` / `set_linger` socket-option helpers.

## Tests

- `DisableNagleHelperTest` — pin the helper's contract (sets `TCP_NODELAY`; best-effort on closed sockets).
- `GatewayConnectionNagleIntegrationTest::test_gateway_connection_has_tcp_nodelay` — opens a real `JavaGateway`, makes one JVM call, asserts the pooled connection's socket has `TCP_NODELAY` enabled. Regression guard against accidentally dropping or moving the `disable_nagle()` call.
- `GatewayConnectionNagleIntegrationTest::test_bytebuffer_array_8k_does_not_take_seconds` — runs issue #516's exact reproducer (100× `ByteBuffer.allocate(8192).array()`) and asserts it completes well under 1.5 s. Catches Nagle regressions directly at the behavioral level.

## Validation

Incubated in [byteoak/py4j#6](https://github.com/byteoak/py4j/pull/6) — passed the full Python × Java × OS matrix cleanly. CodSpeed comparison shown above.

Credit to @trohwer for surfacing the issue and the original loopback fix proposal in #517.

Closes #516.

Co-authored-by: Isaac